### PR TITLE
Delete redundant pom.xml configuration.

### DIFF
--- a/hippo4j-spring-boot/pom.xml
+++ b/hippo4j-spring-boot/pom.xml
@@ -9,8 +9,6 @@
     </parent>
     <artifactId>hippo4j-spring-boot</artifactId>
     <packaging>pom</packaging>
-    <name>${project.artifactId}</name>
-    <description>Hippo4J Starter List</description>
 
     <modules>
         <module>hippo4j-core-spring-boot-starter</module>


### PR DESCRIPTION
Fixes #324 

Changes proposed in this pull request:
- Delete redundant pom.xml configuration.

> Check mailbox configuration when submitting. https://hippo4j.cn/docs/other/contributor
