### PR TITLE
hippo4j-console pom 多余配置删除

### DIFF
--- a/hippo4j-console/pom.xml
+++ b/hippo4j-console/pom.xml
@@ -9,10 +9,6 @@
     </parent>
 
     <artifactId>hippo4j-console</artifactId>
-    <packaging>jar</packaging>
-
-    <name>${project.artifactId}</name>
-    <description>${project.artifactId}</description>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>


### PR DESCRIPTION
Fixes #I #320

Changes proposed in this pull request:
-  delete [packing,name,description] in pom.xml of hippo4j-console module.