### PR TITLE
Hippo4j: adjust the address information of hippo4j project, and replace mabaiwan/hippo4j with opengoofy/hippo4j

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,7 +7,7 @@ about: 提交问题缺陷帮助我们更好的改进
 
 在开始报告错误之前，请确保认真查看了以下步骤：
 
-- 搜索打开和关闭的 [GitHub 问题](https://github.com/mabaiwan/hippo4j/issues)
+- 搜索打开和关闭的 [GitHub 问题](https://github.com/opengoofy/hippo4j/issues)
 - 阅读 [常见问题文档](https://hippo4j.cn/pages/9cc27d/)
 
 请在提交问题之前回答这些问题，谢谢。

--- a/.github/ISSUE_TEMPLATE/question-report.md
+++ b/.github/ISSUE_TEMPLATE/question-report.md
@@ -7,7 +7,7 @@ about: 文档或讨论中未回答的使用问题
 
 在开始报告问题之前，请确保认真查看了以下步骤：
 
-- 搜索打开和关闭的 [GitHub 问题](https://github.com/mabaiwan/hippo4j/issues)
+- 搜索打开和关闭的 [GitHub 问题](https://github.com/opengoofy/hippo4j/issues)
 - 阅读 [常见问题文档](https://hippo4j.cn/pages/9cc27d/)
 
 请在提交问题之前回答这些问题，谢谢。

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/opengoofy/hippo4j/blob/develop/LICENSE">
     <img src="https://img.shields.io/github/license/opengoofy/hippo4j?color=42b883&style=flat-square" alt="LICENSE">
   </a>
-  <a title="Hits" target="_blank" href="https://github.com/mabaiwan/hippo4j">
+  <a title="Hits" target="_blank" href="https://github.com/opengoofy/hippo4j">
     <img src="https://hits.b3log.org/acmenlt/dynamic-threadpool.svg">
   </a>
 </p>

--- a/docs/blog/2022-06-06-hippo4j/index.md
+++ b/docs/blog/2022-06-06-hippo4j/index.md
@@ -124,7 +124,7 @@ Hippo-4J 获得了一些宝贵的荣誉，这属于每一位对 Hippo-4J 做出�
 
 感谢所有为 Hippo-4J 做出贡献的开发者！
 
-https://github.com/mabaiwan/hippo4j/graphs/contributors
+https://github.com/opengoofy/hippo4j/graphs/contributors
 
 ![图4 Hippo-4J 开发者](https://images-machen.oss-cn-beijing.aliyuncs.com/image-20220605151136276.png)
 
@@ -134,12 +134,12 @@ https://github.com/mabaiwan/hippo4j/graphs/contributors
 
 开源不易，如果各位小伙伴看了 Hippo-4J 框架后有所收获，希望能帮忙在 Github、Gitee 点个 star，谢谢。
 
-**Github**：https://github.com/mabaiwan/hippo4j
+**Github**：https://github.com/opengoofy/hippo4j
 
 **Gitee**：https://gitee.com/mabaiwancn/hippo4j
 
 目前已有 **10+** 公司在生产环境使用 Hippo-4J，如果贵公司使用了 Hippo-4J，请在下方 Issue 登记，谢谢。
 
-**Issue**：https://github.com/mabaiwan/hippo4j/issues/13
+**Issue**：https://github.com/opengoofy/hippo4j/issues/13
 
 登记使用不会对公司有任何影响，仅为了扩大 Hippo-4J 影响力，帮助它能走得更远。

--- a/docs/blog/authors.yml
+++ b/docs/blog/authors.yml
@@ -1,5 +1,5 @@
 xiaomage:
   name: 小马哥
   title: hippo4j 作者
-  url: https://github.com/mabaiwan
+  url: https://github.com/opengoofy
   image_url: https://avatars.githubusercontent.com/u/77398366?v=4

--- a/docs/docs/community/developer.md
+++ b/docs/docs/community/developer.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 
 <table>
   <tr>
-    <td align="center"><a href="https://github.com/mabaiwan"><img src="https://avatars.githubusercontent.com/u/77398366?v=4?s=100" width="100px;" alt=""/><br /><sub><b>马称</b></sub></a></td>
+    <td align="center"><a href="https://github.com/opengoofy"><img src="https://avatars.githubusercontent.com/u/77398366?v=4?s=100" width="100px;" alt=""/><br /><sub><b>马称</b></sub></a></td>
     <td align="center"><a href="https://github.com/shining-stars-lk"><img src="https://avatars.githubusercontent.com/u/40255310?v=4?s=100" width="100px;" alt=""/><br /><sub><b>陆宽</b></sub></a></td>
   </tr>
 </table>

--- a/docs/docs/user_docs/user_guide/quick-start.md
+++ b/docs/docs/user_docs/user_guide/quick-start.md
@@ -14,7 +14,7 @@ Clone Hippo4J [源代码](https://github.com/longtai-cn/hippo4j)，导入初始�
 
 1. 导入 [Hippo4J 初始化 SQL 语句](https://github.com/longtai-cn/hippo4j/blob/develop/hippo4j-server/conf/hippo4j_manager.sql)；
 2. 启动 [Hippo4J-Server](https://github.com/longtai-cn/hippo4j/tree/develop/hippo4j-server) 模块下 ServerApplication 应用类；
-3. 启动 [Hippo4J-spring-boot-starter-example](https://github.com/mabaiwan/hippo4j/tree/develop/hippo4j-example/hippo4j-spring-boot-starter-example) 模块下 Hippo4JServerExampleApplication 应用类；
+3. 启动 [Hippo4J-spring-boot-starter-example](https://github.com/opengoofy/hippo4j/tree/develop/hippo4j-example/hippo4j-spring-boot-starter-example) 模块下 Hippo4JServerExampleApplication 应用类；
 
 
 通过接口修改线程池中的配置。HTTP POST 路径：`http://localhost:6691/hippo4j/v1/cs/configs`，Body 请求体如下：

--- a/hippo4j-example/hippo4j-example-core/src/main/java/cn/hippo4j/example/core/inittest/RunStateHandlerTest.java
+++ b/hippo4j-example/hippo4j-example-core/src/main/java/cn/hippo4j/example/core/inittest/RunStateHandlerTest.java
@@ -79,7 +79,7 @@ public class RunStateHandlerTest {
             /**
              * 当线程池任务执行超时, 向 MDC 放入 Trace 标识, 报警时打印出来.
              */
-            MDC.put(EXECUTE_TIMEOUT_TRACE, "https://github.com/mabaiwan/hippo4j 感觉不错来个 Star.");
+            MDC.put(EXECUTE_TIMEOUT_TRACE, "https://github.com/opengoofy/hippo4j 感觉不错来个 Star.");
             ThreadUtil.sleep(5000);
             for (int i = 0; i < Integer.MAX_VALUE; i++) {
                 try {

--- a/pom.xml
+++ b/pom.xml
@@ -417,7 +417,7 @@
         </plugins>
     </build>
 
-    <url>https://github.com/mabaiwan/hippo4j</url>
+    <url>https://github.com/opengoofy/hippo4j</url>
 
     <licenses>
         <license>
@@ -431,7 +431,7 @@
         <developer>
             <name>chen.ma</name>
             <email>machen@apache.org</email>
-            <url>https://github.com/mabaiwan</url>
+            <url>https://github.com/opengoofy</url>
             <organization>OpenGoofy</organization>
             <organizationUrl>https://github.com/opengoofy</organizationUrl>
             <roles>
@@ -446,14 +446,14 @@
     </developers>
 
     <scm>
-        <connection>scm:git@github.com:mabaiwan/hippo4j</connection>
-        <developerConnection>scm:git@github.com:mabaiwan/hippo4j.git</developerConnection>
-        <url>git@github.com:mabaiwan/hippo4j.git</url>
+        <connection>scm:git@github.com:opengoofy/hippo4j</connection>
+        <developerConnection>scm:git@github.com:opengoofy/hippo4j.git</developerConnection>
+        <url>git@github.com:opengoofy/hippo4j.git</url>
     </scm>
 
     <issueManagement>
         <system>Github Issue</system>
-        <url>https://github.com/mabaiwan/hippo4j/issues</url>
+        <url>https://github.com/opengoofy/hippo4j/issues</url>
     </issueManagement>
 
     <distributionManagement>


### PR DESCRIPTION
hippo4j：调整 hippo4j 项目地址信息，将 mabaiwan/hippo4j 替换为 opengoofy/hippo4j
涉及替换文件：
pom.xml
.github/ISSUE_TEMPLATE/bug-report.md
.github/ISSUE_TEMPLATE/question-report.md
.github/ISSUE_TEMPLATE/question-report.md
README.md
docs/blog/2022-06-06-hippo4j/index.md
docs/blog/authors.yml
docs/docs/community/developer.md
docs/docs/user_docs/user_guide/quick-start.md
hippo4j-example/hippo4j-example-core/src/main/java/cn/hippo4j/example/core/inittest/RunStateHandlerTest.java