### PR TITLE
feat:客户端和服务端新增是否鉴权开关

### DIFF
--- a/hippo4j-auth/src/main/java/cn/hippo4j/auth/config/GlobalSecurityConfig.java
+++ b/hippo4j-auth/src/main/java/cn/hippo4j/auth/config/GlobalSecurityConfig.java
@@ -22,6 +22,7 @@ import cn.hippo4j.auth.filter.JWTAuthenticationFilter;
 import cn.hippo4j.auth.filter.JWTAuthorizationFilter;
 import cn.hippo4j.auth.security.JwtTokenManager;
 import cn.hippo4j.auth.service.impl.UserDetailsServiceImpl;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -50,6 +51,8 @@ import java.util.stream.Stream;
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class GlobalSecurityConfig extends WebSecurityConfigurerAdapter {
 
+    @Value("${spring.dynamic.thread-pool.enableAuthentication:true}")
+    private Boolean enableAuthentication;
     @Resource
     private UserDetailsService userDetailsService;
 
@@ -93,16 +96,26 @@ public class GlobalSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/static/**", "/index.html", "/favicon.ico", "/avatar.jpg").permitAll()
                 .antMatchers("/doc.html", "/swagger-resources/**", "/webjars/**", "/*/api-docs").anonymous()
-                .anyRequest().authenticated()
+                // .anyRequest().authenticated()
                 .and()
                 .addFilter(new JWTAuthenticationFilter(authenticationManager()))
                 .addFilter(new JWTAuthorizationFilter(tokenManager, authenticationManager()))
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        disableAuthenticationIfNeeded(http);
+        http.authorizeRequests().anyRequest().authenticated();
     }
 
     @Override
     public void configure(WebSecurity web) throws Exception {
         String[] ignores = Stream.of("/hippo4j/v1/cs/auth/users/apply/token/**").toArray(String[]::new);
         web.ignoring().antMatchers(ignores);
+    }
+
+    private void disableAuthenticationIfNeeded(HttpSecurity http) throws Exception {
+        if (Boolean.FALSE.equals(enableAuthentication)) {
+            http.authorizeRequests().antMatchers("/hippo4j/v1/cs/**").permitAll();
+        }
+
     }
 }

--- a/hippo4j-auth/src/main/java/cn/hippo4j/auth/filter/JWTAuthenticationFilter.java
+++ b/hippo4j-auth/src/main/java/cn/hippo4j/auth/filter/JWTAuthenticationFilter.java
@@ -34,7 +34,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -69,6 +68,7 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         Authentication authenticate = null;
         try {
             LoginUser loginUser = new ObjectMapper().readValue(request.getInputStream(), LoginUser.class);
+            request.setAttribute("loginUser", loginUser);
             rememberMe.set(loginUser.getRememberMe());
             authenticate = authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(loginUser.getUsername(), loginUser.getPassword(), new ArrayList()));

--- a/hippo4j-auth/src/main/java/cn/hippo4j/auth/service/impl/UserDetailsServiceImpl.java
+++ b/hippo4j-auth/src/main/java/cn/hippo4j/auth/service/impl/UserDetailsServiceImpl.java
@@ -20,14 +20,22 @@ package cn.hippo4j.auth.service.impl;
 import cn.hippo4j.auth.mapper.UserMapper;
 import cn.hippo4j.auth.model.UserInfo;
 import cn.hippo4j.auth.model.biz.user.JwtUser;
+import cn.hippo4j.auth.model.biz.user.LoginUser;
+import cn.hutool.core.util.ObjectUtil;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
@@ -41,8 +49,16 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     @Resource
     private UserMapper userMapper;
 
+    @Value("${spring.dynamic.thread-pool.enableAuthentication:true}")
+    private Boolean enableAuthentication;
+
     @Override
     public UserDetails loadUserByUsername(String userName) throws UsernameNotFoundException {
+
+        JwtUser anonymous = dealWithAnonymous();
+        if (ObjectUtil.isNotNull(anonymous)) {
+            return anonymous;
+        }
         UserInfo userInfo = userMapper.selectOne(Wrappers.lambdaQuery(UserInfo.class).eq(UserInfo::getUserName, userName));
         if (Objects.isNull(userInfo)) {
             log.warn("User {} not found", userName);
@@ -55,5 +71,28 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority(userInfo.getRole() + ""));
         jwtUser.setAuthorities(authorities);
         return jwtUser;
+    }
+
+    private JwtUser dealWithAnonymous() {
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        if (requestAttributes == null) {
+            return null;
+        }
+        HttpServletRequest request = ((ServletRequestAttributes) requestAttributes).getRequest();
+        LoginUser loginUser = (LoginUser) request.getAttribute("loginUser");
+        if (ObjectUtil.isNull(loginUser)) {
+            return null;
+        }
+        if (Boolean.FALSE.equals(enableAuthentication)) {
+            JwtUser jwtUser = new JwtUser();
+            BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
+            jwtUser.setId(1L);
+            jwtUser.setUsername("anonymous");
+            jwtUser.setPassword(bCryptPasswordEncoder.encode(loginUser.getPassword()));
+            Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_ADMIN"));
+            jwtUser.setAuthorities(authorities);
+            return jwtUser;
+        }
+        return null;
     }
 }

--- a/hippo4j-core/src/main/java/cn/hippo4j/core/config/BootstrapPropertiesInterface.java
+++ b/hippo4j-core/src/main/java/cn/hippo4j/core/config/BootstrapPropertiesInterface.java
@@ -31,6 +31,10 @@ public interface BootstrapPropertiesInterface {
         return null;
     }
 
+    default Boolean getEnableAuthentication() {
+        return null;
+    }
+
     /**
      * Get username.
      *

--- a/hippo4j-core/src/main/java/cn/hippo4j/core/enable/BeforeCheckConfiguration.java
+++ b/hippo4j-core/src/main/java/cn/hippo4j/core/enable/BeforeCheckConfiguration.java
@@ -41,7 +41,7 @@ public class BeforeCheckConfiguration {
     public BeforeCheckConfiguration.BeforeCheck dynamicThreadPoolBeforeCheckBean(@Autowired(required = false) BootstrapPropertiesInterface properties,
                                                                                  ConfigurableEnvironment environment) {
         boolean checkFlag = properties != null && Objects.equals(bootstrapPropertiesClassName, properties.getClass().getName()) && properties.getEnable();
-        if (checkFlag) {
+        if (checkFlag && Boolean.TRUE.equals(properties.getEnableAuthentication())) {
             String username = properties.getUsername();
             if (StringUtil.isBlank(username)) {
                 throw new ConfigEmptyException(

--- a/hippo4j-example/hippo4j-spring-boot-starter-example/src/main/resources/application.properties
+++ b/hippo4j-example/hippo4j-spring-boot-starter-example/src/main/resources/application.properties
@@ -17,6 +17,7 @@ spring.dynamic.thread-pool.namespace=prescription
 spring.dynamic.thread-pool.item-id=dynamic-threadpool-example
 spring.dynamic.thread-pool.username=admin
 spring.dynamic.thread-pool.password=123456
+spring.dynamic.thread-pool.enableAuthentication=true
 
 # Enable server and micrometer monitoring at the same time
 spring.dynamic.thread-pool.collect-type=server,micrometer

--- a/hippo4j-server/src/main/resources/application.properties
+++ b/hippo4j-server/src/main/resources/application.properties
@@ -53,3 +53,5 @@ mybatis-plus.global-config.banner=false
 mybatis-plus.global-config.db-config.logic-delete-field=delFlag
 mybatis-plus.global-config.db-config.logic-delete-value=1
 mybatis-plus.global-config.db-config.logic-not-delete-value=0
+
+spring.dynamic.thread-pool.enableAuthentication=true

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/config/BootstrapProperties.java
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/config/BootstrapProperties.java
@@ -103,4 +103,9 @@ public class BootstrapProperties implements BootstrapPropertiesInterface {
      * Time interval for client to collect monitoring data. unit: ms
      */
     private Long collectInterval = 5000L;
+
+    /**
+     * Whether to enable authentication
+     */
+    private Boolean enableAuthentication = true;
 }

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/security/SecurityProxy.java
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/security/SecurityProxy.java
@@ -53,9 +53,12 @@ public class SecurityProxy {
 
     private long tokenRefreshWindow;
 
+    private boolean enableAuthentication;
+
     public SecurityProxy(HttpClientUtil httpClientUtil, BootstrapProperties properties) {
         username = properties.getUsername();
         password = properties.getPassword();
+        enableAuthentication = properties.getEnableAuthentication();
         this.httpClientUtil = httpClientUtil;
     }
 
@@ -65,6 +68,9 @@ public class SecurityProxy {
                 return true;
             }
             for (String server : servers) {
+                if (!enableAuthentication) {
+                    return true;
+                }
                 if (applyToken(server)) {
                     lastRefreshTime = System.currentTimeMillis();
                     return true;


### PR DESCRIPTION
# Fixes #60

# 测试用例:
## 1.服务端开启 spring.dynamic.thread-pool.enableAuthentication=fase
- 管理页面即可不输入账户和密码登录,默认为 ROLE_ADMIN 角色
> 由于前端页面默认进行密码长度校验,随机输入即可登录.待前端校验去除后无需输入密码即可登录
- 客户端无论是否开启校验,访问服务端无需进行鉴权校验

## 1.服务端开启 spring.dynamic.thread-pool.enableAuthentication=true
- 管理页面需要账户和密码进行登录验证
- 客户端无论是否开启校验,都需要进行认证(即输入账户和密码)