### PR TITLE
docker-startup.sh的mysql配置多个“-”修复

### DIFF
--- a/hippo4j-server/hippo4j-bootstrap/docker-startup.sh
+++ b/hippo4j-server/hippo4j-bootstrap/docker-startup.sh
@@ -20,7 +20,7 @@ JAVA_OPT="${JAVA_OPT} --server.tomcat.basedir=${BASE_DIR}/bin"
 
 if [[ "${DATASOURCE_MODE}" == "mysql" ]]; then
   JAVA_OPT="${JAVA_OPT} --spring.datasource.url=\"jdbc:mysql://${DATASOURCE_HOST}:${DATASOURCE_PORT}/${DATASOURCE_DB}?characterEncoding=utf-8&zeroDateTimeBehavior=convertToNull&transformedBitIsBoolean=true&serverTimezone=GMT%2B8\" "
-  JAVA_OPT="${JAVA_OPT} ---spring.datasource.username=${DATASOURCE_USERNAME} --spring.datasource.password=${DATASOURCE_PASSWORD} "
+  JAVA_OPT="${JAVA_OPT} --spring.datasource.username=${DATASOURCE_USERNAME} --spring.datasource.password=${DATASOURCE_PASSWORD} "
 elif [[ "${DATASOURCE_MODE}" == "h2" ]]; then
   JAVA_OPT="${JAVA_OPT} --spring.profiles.active=h2 --spring.datasource.url=jdbc:h2:file:${BASE_DIR}/h2_hippo4j;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL"
 else


### PR DESCRIPTION
Fixes #839 
