### PR TITLE
smart h2 storage path

### DIFF
--- a/hippo4j-server/hippo4j-bootstrap/src/main/resources/application-h2.properties
+++ b/hippo4j-server/hippo4j-bootstrap/src/main/resources/application-h2.properties
@@ -4,6 +4,6 @@ hippo4j.database.init_enable=true
 hippo4j.database.init_script=sql-script/h2/hippo4j_manager.sql
 
 spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.url=jdbc:h2:file:{your storage address}/h2_hippo4j_test_file;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL;
+spring.datasource.url=jdbc:h2:file:${HOME:${HOMEDRIVE}${HOMEPATH}}/h2_hippo4j_test_file;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL;
 spring.datasource.username=sa
 spring.datasource.password=sa


### PR DESCRIPTION
No longer need to manually specify the storage path for the H2 database. Increased sense of experience.