### PR TITLE
Add benchmark test for TaskTimeRecord

### DIFF
--- a/hippo4j-example/hippo4j-example-core/pom.xml
+++ b/hippo4j-example/hippo4j-example-core/pom.xml
@@ -34,5 +34,20 @@
             <groupId>com.alibaba</groupId>
             <artifactId>transmittable-thread-local</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.23</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.23</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/hippo4j-example/hippo4j-example-core/src/test/java/cn/hippo4j/example/core/TaskTimeRecordPluginBenchmarkTest.java
+++ b/hippo4j-example/hippo4j-example-core/src/test/java/cn/hippo4j/example/core/TaskTimeRecordPluginBenchmarkTest.java
@@ -1,0 +1,151 @@
+package cn.hippo4j.example.core;
+
+import cn.hippo4j.core.executor.ExtensibleThreadPoolExecutor;
+import cn.hippo4j.core.plugin.impl.TaskTimeRecordPlugin;
+import cn.hippo4j.core.plugin.manager.DefaultThreadPoolPluginManager;
+import lombok.SneakyThrows;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * benchmark test for {@link cn.hippo4j.core.plugin.impl.TaskTimeRecordPlugin}
+ */
+@BenchmarkMode(Mode.All)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 1)
+@Measurement(iterations = 3)
+@Fork(1)
+@Threads(6)
+public class TaskTimeRecordPluginBenchmarkTest {
+
+    @SneakyThrows
+    @Benchmark
+    public void origin_200(Blackhole blackhole) {
+        int threadCount = 200;
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+            threadCount, threadCount, 1000L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(threadCount), Thread::new, new ThreadPoolExecutor.DiscardPolicy());
+        executor.prestartAllCoreThreads();
+
+        List<Runnable> tasks = getTask(threadCount, blackhole);
+        tasks.forEach(executor::execute);
+
+        executor.shutdown();
+        while (!executor.isTerminated()) {}
+    }
+
+    @SneakyThrows
+    @Benchmark
+    public void origin_50(Blackhole blackhole) {
+        int threadCount = 50;
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+            threadCount, threadCount, 1000L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(threadCount), Thread::new, new ThreadPoolExecutor.DiscardPolicy());
+        executor.prestartAllCoreThreads();
+
+        List<Runnable> tasks = getTask(threadCount, blackhole);
+        tasks.forEach(executor::execute);
+
+        executor.shutdown();
+        while (!executor.isTerminated()) {}
+    }
+
+    @SneakyThrows
+    @Benchmark
+    public void not_plugin_50(Blackhole blackhole) {
+        int threadCount = 50;
+        ExtensibleThreadPoolExecutor executor = new ExtensibleThreadPoolExecutor(
+            "test", new DefaultThreadPoolPluginManager(),
+            threadCount, threadCount, 1000L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(threadCount), Thread::new, new ThreadPoolExecutor.DiscardPolicy());
+        executor.prestartAllCoreThreads();
+
+        List<Runnable> tasks = getTask(threadCount, blackhole);
+        tasks.forEach(executor::execute);
+
+        executor.shutdown();
+        while (!executor.isTerminated()) {}
+    }
+
+    @SneakyThrows
+    @Benchmark
+    public void not_plugin_200(Blackhole blackhole) {
+        int threadCount = 200;
+        ExtensibleThreadPoolExecutor executor = new ExtensibleThreadPoolExecutor(
+            "test", new DefaultThreadPoolPluginManager(),
+            threadCount, threadCount, 1000L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(threadCount), Thread::new, new ThreadPoolExecutor.DiscardPolicy());
+        executor.prestartAllCoreThreads();
+
+        List<Runnable> tasks = getTask(threadCount, blackhole);
+        tasks.forEach(executor::execute);
+
+        executor.shutdown();
+        while (!executor.isTerminated()) {}
+    }
+
+    @SneakyThrows
+    @Benchmark
+    public void plugin_50(Blackhole blackhole) {
+        int threadCount = 50;
+        ExtensibleThreadPoolExecutor executor = new ExtensibleThreadPoolExecutor(
+            "test", new DefaultThreadPoolPluginManager(),
+            threadCount, threadCount, 1000L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(threadCount), Thread::new, new ThreadPoolExecutor.DiscardPolicy());
+        executor.prestartAllCoreThreads();
+        executor.register(new TaskTimeRecordPlugin());
+
+        List<Runnable> tasks = getTask(threadCount, blackhole);
+        tasks.forEach(executor::execute);
+
+        executor.shutdown();
+        while (!executor.isTerminated()) {}
+    }
+
+    @SneakyThrows
+    @Benchmark
+    public void plugin_200(Blackhole blackhole) {
+        int threadCount = 200;
+        ExtensibleThreadPoolExecutor executor = new ExtensibleThreadPoolExecutor(
+            "test", new DefaultThreadPoolPluginManager(),
+            threadCount, threadCount, 1000L, TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(threadCount), Thread::new, new ThreadPoolExecutor.DiscardPolicy());
+        executor.prestartAllCoreThreads();
+        executor.register(new TaskTimeRecordPlugin());
+
+        List<Runnable> tasks = getTask(threadCount, blackhole);
+        tasks.forEach(executor::execute);
+
+        executor.shutdown();
+        while (!executor.isTerminated()) {}
+    }
+
+    private List<Runnable> getTask(int count, Blackhole blackhole) {
+        List<Runnable> tasks = new ArrayList<>(count);
+        for (int i = 1; i < count * 2; i++) {
+            int index = i;
+            tasks.add(() -> blackhole.consume(index));
+        }
+        return tasks;
+    }
+
+    public static void main(String[] args) throws Exception {
+        Options opts = new OptionsBuilder()
+            .include(TaskTimeRecordPluginBenchmarkTest.class.getSimpleName())
+            .resultFormat(ResultFormatType.JSON)
+            .build();
+        new Runner(opts).run();
+    }
+
+}


### PR DESCRIPTION
在 `core-example` 模块简单添加了一个关于 `TaskTimeRecordPlugin` 的性能测试用例。

不知道是不是用例写的有问题，对照中有时间记录插件的线程池和没有时间记录插件的线程池之间，每批任务的总运行只差一点点。

如果更正用例后 `TaskTimeRecordPlugin` 出现了比较严重的性能问题，或许可以考虑改进一下该插件，通过类似分段锁的思路缓解锁竞争问题。

比如，将原本的计时逻辑封装为计时器对象，并改令 `TaskTimeRecordPlugin` 通过数组的方式持有 2^n 个计时器实例，当线程记录任务时间的时候，通过 2^n-1 对 `threadId` 取模后得到的下标获取计时器并记录时间：

~~~java
long tid = Thread.currentThread().getId();
int index = (int)(tid & (timerCount - 1));
Timer timer = timers[index];
timre.recordTime(xxxx);
~~~

计时器进行读写的时候才会加锁，这样就将锁的粒度降低了。当获取信息时，遍历数组中的计时器，再将数据汇总即可。