### PR TITLE
 Optimize the lock logic of TaskTimeRecordPlugin

### DIFF
--- a/hippo4j-core/src/main/java/cn/hippo4j/core/plugin/impl/TaskTimeRecordPlugin.java
+++ b/hippo4j-core/src/main/java/cn/hippo4j/core/plugin/impl/TaskTimeRecordPlugin.java
@@ -17,46 +17,61 @@
 
 package cn.hippo4j.core.plugin.impl;
 
+import cn.hippo4j.common.toolkit.Assert;
 import cn.hippo4j.core.plugin.PluginRuntime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 /**
- * Record task execution time indicator.
+ * <p>Record task execution time indicator. <br />
+ * The initialization size of the timer container can be specified during construction,
+ * It will route it to different timers in the container according to the {@link Thread#getId},
+ * to reduce the lock competition strength for a single timer.
  */
-@RequiredArgsConstructor
 public class TaskTimeRecordPlugin extends AbstractTaskTimerPlugin {
 
+    static final int MAXIMUM_CAPACITY = 1 << 30;
     public static final String PLUGIN_NAME = "task-time-record-plugin";
 
     /**
-     * Lock instance
+     * modulo
      */
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final int modulo;
 
     /**
-     * Total execution milli time of all tasks
+     * timers
      */
-    private long totalTaskTimeMillis = 0L;
+    public final List<Timer> timerTable;
 
     /**
-     * Maximum task milli execution time, default -1
+     * Create a {@link TaskTimeRecordPlugin}
+     *
+     * @param initialCapacity initial capacity of timer table
      */
-    private long maxTaskTimeMillis = -1L;
+    public TaskTimeRecordPlugin(int initialCapacity) {
+        Assert.isTrue(initialCapacity >= 1, "count must great then 0");
+        initialCapacity = tableSizeFor(initialCapacity);
+        timerTable = new ArrayList<>(initialCapacity);
+        for (int i = 0; i < initialCapacity; i++) {
+            timerTable.add(new Timer());
+        }
+        modulo = initialCapacity - 1;
+    }
 
     /**
-     * Minimal task milli execution time, default -1
+     * Create a {@link TaskTimeRecordPlugin}
      */
-    private long minTaskTimeMillis = -1L;
-
-    /**
-     * Count of completed task
-     */
-    private long taskCount = 0L;
+    public TaskTimeRecordPlugin() {
+        this(1);
+    }
 
     /**
      * Get id.
@@ -91,21 +106,8 @@ public class TaskTimeRecordPlugin extends AbstractTaskTimerPlugin {
      */
     @Override
     protected void processTaskTime(long taskExecuteTime) {
-        Lock writeLock = lock.writeLock();
-        writeLock.lock();
-        try {
-            if (taskCount == 0) {
-                maxTaskTimeMillis = taskExecuteTime;
-                minTaskTimeMillis = taskExecuteTime;
-            } else {
-                maxTaskTimeMillis = Math.max(taskExecuteTime, maxTaskTimeMillis);
-                minTaskTimeMillis = Math.min(taskExecuteTime, minTaskTimeMillis);
-            }
-            taskCount = taskCount + 1;
-            totalTaskTimeMillis += taskExecuteTime;
-        } finally {
-            writeLock.unlock();
-        }
+        Timer timer = getTimerForCurrentThread();
+        timer.recordTaskTime(taskExecuteTime);
     }
 
     /**
@@ -114,19 +116,132 @@ public class TaskTimeRecordPlugin extends AbstractTaskTimerPlugin {
      * @return data snapshot
      */
     public Summary summarize() {
-        Lock readLock = lock.readLock();
-        Summary statistics;
-        readLock.lock();
-        try {
-            statistics = new Summary(
-                    this.totalTaskTimeMillis,
-                    this.maxTaskTimeMillis,
-                    this.minTaskTimeMillis,
-                    this.taskCount);
-        } finally {
-            readLock.unlock();
+        // ignore unused timers
+        List<Summary> summaries = timerTable.stream()
+                .map(Timer::summarize)
+                .filter(s -> s.getTaskCount() > 0)
+                .collect(Collectors.toList());
+
+        // summarize data
+        long totalTaskTimeMillis = 0L;
+        long maxTaskTimeMillis = -1L;
+        long minTaskTimeMillis = -1L;
+        long taskCount = 0L;
+        for (Summary summary : summaries) {
+            if (taskCount > 0) {
+                maxTaskTimeMillis = Math.max(maxTaskTimeMillis, summary.getMaxTaskTimeMillis());
+                minTaskTimeMillis = Math.min(minTaskTimeMillis, summary.getMinTaskTimeMillis());
+            } else {
+                maxTaskTimeMillis = summary.getMaxTaskTimeMillis();
+                minTaskTimeMillis = summary.getMinTaskTimeMillis();
+            }
+            totalTaskTimeMillis += summary.getTotalTaskTimeMillis();
+            taskCount += summary.getTaskCount();
         }
-        return statistics;
+        return new Summary(totalTaskTimeMillis, maxTaskTimeMillis, minTaskTimeMillis, taskCount);
+    }
+
+    private Timer getTimerForCurrentThread() {
+        /*
+         * use table tableSize - 1 to take modulus for tid, and the remainder obtained is the subscript of the timer corresponding to the thread in the table. eg: tid = 10086, tableSize = 8, 10086 &
+         * (8 - 1) = 4
+         */
+        long threadId = Thread.currentThread().getId();
+        int index = (int) (threadId & modulo);
+        return timerTable.get(index);
+    }
+
+    /**
+     * copy from {@link HashMap#tableSizeFor}
+     */
+    static int tableSizeFor(int cap) {
+        int n = cap - 1;
+        n |= n >>> 1;
+        n |= n >>> 2;
+        n |= n >>> 4;
+        n |= n >>> 8;
+        n |= n >>> 16;
+        if (n < 0) {
+            return 1;
+        }
+        return n >= MAXIMUM_CAPACITY ? MAXIMUM_CAPACITY : n + 1;
+    }
+
+    /**
+     * <p>Independent unit for providing time recording function.<br />
+     * Support thread-safe operations when reading and writing in a concurrent environment.
+     */
+    private static class Timer {
+
+        /**
+         * Lock instance
+         */
+        private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+        /**
+         * Total execution milli time of all tasks
+         */
+        private long totalTaskTimeMillis = 0L;
+
+        /**
+         * Maximum task milli execution time, default -1
+         */
+        private long maxTaskTimeMillis = -1L;
+
+        /**
+         * Minimal task milli execution time, default -1
+         */
+        private long minTaskTimeMillis = -1L;
+
+        /**
+         * Count of completed task
+         */
+        private long taskCount = 0L;
+
+        /**
+         * Record task execute time.
+         *
+         * @param taskExecuteTime task execute time
+         */
+        public void recordTaskTime(long taskExecuteTime) {
+            Lock writeLock = lock.writeLock();
+            writeLock.lock();
+            try {
+                if (taskCount == 0) {
+                    maxTaskTimeMillis = taskExecuteTime;
+                    minTaskTimeMillis = taskExecuteTime;
+                } else {
+                    maxTaskTimeMillis = Math.max(taskExecuteTime, maxTaskTimeMillis);
+                    minTaskTimeMillis = Math.min(taskExecuteTime, minTaskTimeMillis);
+                }
+                taskCount = taskCount + 1;
+                totalTaskTimeMillis += taskExecuteTime;
+            } finally {
+                writeLock.unlock();
+            }
+        }
+
+        /**
+         * Get the summary statistics of the instance at the current time.
+         *
+         * @return data snapshot
+         */
+        public Summary summarize() {
+            Lock readLock = lock.readLock();
+            Summary statistics;
+            readLock.lock();
+            try {
+                statistics = new Summary(
+                        this.totalTaskTimeMillis,
+                        this.maxTaskTimeMillis,
+                        this.minTaskTimeMillis,
+                        this.taskCount);
+            } finally {
+                readLock.unlock();
+            }
+            return statistics;
+        }
+
     }
 
     /**
@@ -166,4 +281,5 @@ public class TaskTimeRecordPlugin extends AbstractTaskTimerPlugin {
             return totalTaskCount > 0L ? getTotalTaskTimeMillis() / totalTaskCount : -1;
         }
     }
+
 }

--- a/hippo4j-core/src/test/java/cn/hippo4j/core/plugin/impl/TaskTimeRecordPluginTest.java
+++ b/hippo4j-core/src/test/java/cn/hippo4j/core/plugin/impl/TaskTimeRecordPluginTest.java
@@ -20,6 +20,7 @@ package cn.hippo4j.core.plugin.impl;
 import cn.hippo4j.common.toolkit.ThreadUtil;
 import cn.hippo4j.core.executor.ExtensibleThreadPoolExecutor;
 import cn.hippo4j.core.plugin.manager.DefaultThreadPoolPluginManager;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * test for {@link TaskTimeRecordPlugin}
  */
+@Slf4j
 public class TaskTimeRecordPluginTest {
 
     @Test
@@ -61,9 +63,17 @@ public class TaskTimeRecordPluginTest {
         while (!executor.isTerminated()) {
         }
         TaskTimeRecordPlugin.Summary summary = plugin.summarize();
-        Assert.assertEquals(1, summary.getMinTaskTimeMillis() / 1000L);
-        Assert.assertEquals(3, summary.getMaxTaskTimeMillis() / 1000L);
-        Assert.assertEquals(2, summary.getAvgTaskTimeMillis() / 1000L);
-        Assert.assertEquals(8, summary.getTotalTaskTimeMillis() / 1000L);
+        Assert.assertTrue(testInDeviation(summary.getMinTaskTimeMillis(), 1000L, 300L));
+        Assert.assertTrue(testInDeviation(summary.getMaxTaskTimeMillis(), 3000L, 300L));
+        Assert.assertTrue(testInDeviation(summary.getAvgTaskTimeMillis(), 2000L, 300L));
+        Assert.assertTrue(testInDeviation(summary.getTotalTaskTimeMillis(), 8000L, 300L));
     }
+
+    private boolean testInDeviation(long except, long actual, long offer) {
+        long exceptLower = except - offer;
+        long exceptUpper = except + offer;
+        log.info("test {} < [{}] < {}", exceptLower, actual, exceptUpper);
+        return exceptLower < actual && actual < exceptUpper;
+    }
+
 }

--- a/hippo4j-core/src/test/java/cn/hippo4j/core/plugin/impl/TaskTimeRecordPluginTest.java
+++ b/hippo4j-core/src/test/java/cn/hippo4j/core/plugin/impl/TaskTimeRecordPluginTest.java
@@ -54,6 +54,7 @@ public class TaskTimeRecordPluginTest {
         executor.submit(() -> ThreadUtil.sleep(1000L));
         executor.submit(() -> ThreadUtil.sleep(3000L));
         executor.submit(() -> ThreadUtil.sleep(2000L));
+        executor.submit(() -> ThreadUtil.sleep(2000L));
 
         // waiting for shutdown
         executor.shutdown();
@@ -63,6 +64,6 @@ public class TaskTimeRecordPluginTest {
         Assert.assertEquals(1, summary.getMinTaskTimeMillis() / 1000L);
         Assert.assertEquals(3, summary.getMaxTaskTimeMillis() / 1000L);
         Assert.assertEquals(2, summary.getAvgTaskTimeMillis() / 1000L);
-        Assert.assertEquals(6, summary.getTotalTaskTimeMillis() / 1000L);
+        Assert.assertEquals(8, summary.getTotalTaskTimeMillis() / 1000L);
     }
 }

--- a/hippo4j-core/src/test/java/cn/hippo4j/core/plugin/impl/TaskTimeRecordPluginTest.java
+++ b/hippo4j-core/src/test/java/cn/hippo4j/core/plugin/impl/TaskTimeRecordPluginTest.java
@@ -49,7 +49,7 @@ public class TaskTimeRecordPluginTest {
                 3, 3, 1000L, TimeUnit.MILLISECONDS,
                 new ArrayBlockingQueue<>(1), Thread::new, new ThreadPoolExecutor.DiscardPolicy());
 
-        TaskTimeRecordPlugin plugin = new TaskTimeRecordPlugin();
+        TaskTimeRecordPlugin plugin = new TaskTimeRecordPlugin(3);
         executor.register(plugin);
         executor.submit(() -> ThreadUtil.sleep(1000L));
         executor.submit(() -> ThreadUtil.sleep(3000L));


### PR DESCRIPTION
`TaskTimeRecordPlugin` 是用于统计包括最大、最小、平均和总任务执行时间等各项指标的插件，由于涉及到并发写入，因此它不可避免会面对下述情况：

+ 每一个线程在执行 `afterExecute` 的方法时，都需要获得写锁更新相关的时间指标；
+ 外部尝试读取并计算该线程池的相关时间指标时，也需要获得锁；

当线程池工作线程数量较多，且线程池任务吞吐量较大的情况下，上面情况会不可避免的由于激烈的锁竞争而影响性能。

本 PR 旨在通过以下方案优化数据结构从而缓解由于上述场景造成的性能问题：

**分段锁**：

首先，将各项全局的时间指标维护至一个单独的内部类 `TimeRecorder` 中，其可通过内部的锁线程安全的支持对各项时间指标的写入和读取。

然后，根据分段锁的思路，在 `TaskTimeRecordPlugin` 内部维护一个长度为 2 的次幂的数值 `recorders`，每个槽位中都存放一个 `TimeRecorder` 实例。其中，`recorders` 的长度 `n` 在插件创建时指定后即不能更改（后续直接加锁，或者参照 `ConcurrentHashMap` 实现动态扩容缩容），在构造函数中将参照 `HashMap` 的方式将 `n` 调整为最接近 `n` 的 2 的次幂。

当工作线程需要写入时间指标时，将先获取线程的 `threadId` 然后与 `recorders` 的长度减一进行与运算取模获得要使用的记录器下标，然后根据下标从 `recorders` 获得记录器。（比如，`10086 & (8 - 1) = 4`）

当线程调用 `TimeRecorder` 的 `record` 方法记录时间指标前，记录器将通过加锁保证数据的同步写入。

**快照读**

由于获取时间指标时需要同时获取所有的 `TimeRecorder` 的锁获取统计数据，因此可能在一瞬间导致线程池中所有工作线程进入阻塞。考虑到一般情况下对时间指标的准确性要求并不高（实际上由于网络请求的延迟，也很难保证这点），只要能大致准确反映趋势即可，因此这里决定牺牲一定的准确性和时效性，通过快照读的方式减轻锁的并发读（后续插件可以支持自行选择快照读和当前读两种模式）。

该方案即当从插件中获得时间指标时，将依次取出 `TimeRecorder` ，加锁并获取其基本时间指标，然后就立刻释放锁。依次获取基本时间指标完毕后，再进行汇总统计，然后生成最终的统计数据返回给采集方。

![image](https://github.com/opengoofy/hippo4j/assets/49221670/af7c10e8-5971-4356-88d5-36a8970ccc96)

