### PR TITLE
fix : The rpc module is tuned to start the server asynchronously and …

### DIFF
--- a/hippo4j-rpc/pom.xml
+++ b/hippo4j-rpc/pom.xml
@@ -12,7 +12,7 @@
     <dependencies>
         <dependency>
             <groupId>cn.hippo4j</groupId>
-            <artifactId>hippo4j-common</artifactId>
+            <artifactId>hippo4j-message</artifactId>
             <version>${revision}</version>
         </dependency>
         <dependency>

--- a/hippo4j-rpc/pom.xml
+++ b/hippo4j-rpc/pom.xml
@@ -12,7 +12,7 @@
     <dependencies>
         <dependency>
             <groupId>cn.hippo4j</groupId>
-            <artifactId>hippo4j-message</artifactId>
+            <artifactId>hippo4j-common</artifactId>
             <version>${revision}</version>
         </dependency>
         <dependency>

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/handler/AbstractNettyTakeHandler.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/handler/AbstractNettyTakeHandler.java
@@ -41,7 +41,8 @@ public abstract class AbstractNettyTakeHandler extends ChannelInboundHandlerAdap
         Channel channel = ctx.channel();
         if (channel.isActive()) {
             ctx.close();
-        } else {
+        }
+        if (cause != null) {
             throw new ConnectionException(cause);
         }
     }

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/handler/NettyClientPoolHandler.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/handler/NettyClientPoolHandler.java
@@ -22,6 +22,7 @@ import cn.hippo4j.rpc.coder.NettyEncoder;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.pool.ChannelPoolHandler;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.serialization.ClassResolvers;
@@ -33,40 +34,40 @@ import java.util.List;
  * Processing by the client connection pool handler to clean the buffer and define new connection properties
  */
 @Slf4j
-public class AbstractNettyClientPoolHandler extends AbstractNettyHandlerManager implements ChannelPoolHandler {
+public class NettyClientPoolHandler extends AbstractNettyHandlerManager implements ChannelPoolHandler {
 
-    public AbstractNettyClientPoolHandler(List<ChannelHandler> handlers) {
+    public NettyClientPoolHandler(List<ChannelHandler> handlers) {
         super(handlers);
     }
 
-    public AbstractNettyClientPoolHandler(ChannelHandler... handlers) {
+    public NettyClientPoolHandler(ChannelHandler... handlers) {
         super(handlers);
     }
 
-    public AbstractNettyClientPoolHandler() {
+    public NettyClientPoolHandler() {
         super();
     }
 
     @Override
-    public AbstractNettyClientPoolHandler addLast(String name, ChannelHandler handler) {
+    public NettyClientPoolHandler addLast(String name, ChannelHandler handler) {
         super.addLast(name, handler);
         return this;
     }
 
     @Override
-    public AbstractNettyClientPoolHandler addFirst(String name, ChannelHandler handler) {
+    public NettyClientPoolHandler addFirst(String name, ChannelHandler handler) {
         super.addFirst(name, handler);
         return this;
     }
 
     @Override
-    public AbstractNettyClientPoolHandler addLast(ChannelHandler handler) {
+    public NettyClientPoolHandler addLast(ChannelHandler handler) {
         super.addLast(handler);
         return this;
     }
 
     @Override
-    public AbstractNettyClientPoolHandler addFirst(ChannelHandler handler) {
+    public NettyClientPoolHandler addFirst(ChannelHandler handler) {
         super.addFirst(handler);
         return this;
     }
@@ -87,15 +88,16 @@ public class AbstractNettyClientPoolHandler extends AbstractNettyHandlerManager 
         NioSocketChannel channel = (NioSocketChannel) ch;
         channel.config()
                 .setTcpNoDelay(false);
-        ch.pipeline().addLast(new NettyDecoder(ClassResolvers.cacheDisabled(null)));
-        ch.pipeline().addLast(new NettyEncoder());
+        ChannelPipeline pipeline = ch.pipeline();
+        pipeline.addLast(new NettyEncoder());
+        pipeline.addLast(new NettyDecoder(ClassResolvers.cacheDisabled(null)));
         this.handlerEntities.stream()
                 .sorted()
                 .forEach(h -> {
                     if (h.getName() == null) {
-                        ch.pipeline().addLast(h.getHandler());
+                        pipeline.addLast(h.getHandler());
                     } else {
-                        ch.pipeline().addLast(h.getName(), h.getHandler());
+                        pipeline.addLast(h.getName(), h.getHandler());
                     }
                 });
     }

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/server/RPCServer.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/server/RPCServer.java
@@ -18,8 +18,10 @@
 package cn.hippo4j.rpc.server;
 
 import cn.hippo4j.rpc.discovery.ServerPort;
+import cn.hippo4j.rpc.exception.ConnectionException;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Server Implementation
@@ -34,9 +36,17 @@ public class RPCServer implements Server {
         this.serverConnection = serverConnection;
     }
 
+    /**
+     * Reference from{@link cn.hippo4j.config.netty.MonitorNettyServer}<br>
+     * Start the server side asynchronously
+     */
     @Override
     public void bind() {
-        serverConnection.bind(port);
+        CompletableFuture
+                .runAsync(() -> serverConnection.bind(port))
+                .exceptionally(throwable -> {
+                    throw new ConnectionException(throwable);
+                });
     }
 
     @Override

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/support/ClientFactoryBean.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/support/ClientFactoryBean.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.hippo4j.rpc.support;
+
+import cn.hippo4j.rpc.client.Client;
+import cn.hippo4j.rpc.discovery.DiscoveryAdapter;
+import cn.hippo4j.rpc.exception.ConnectionException;
+import cn.hippo4j.rpc.handler.NettyClientPoolHandler;
+import io.netty.channel.ChannelHandler;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import java.net.InetSocketAddress;
+
+/**
+ * A FactoryBean that builds interfaces to invoke proxy objects
+ * is responsible for managing the entire life cycle of the proxy objects<br>
+ *
+ * @deprecated With {@link cn.hippo4j.config.service.ThreadPoolAdapterService} structure, FactoryBean is not the best choice
+ */
+@Deprecated
+public class ClientFactoryBean implements FactoryBean<Object>, InitializingBean, ApplicationContextAware, DisposableBean {
+
+    /**
+     * Application name or address string. If it is an address string, it must be in ip:port format
+     */
+    private String applicationName;
+
+    /**
+     * The adapter name in the container needs to be used with applicationName
+     * to get the real server address. If it is null or the address information
+     * cannot be found, applicationName is treated as an address string
+     */
+    private String discoveryAdapterName;
+
+    private DiscoveryAdapter discoveryAdapter;
+
+    /**
+     * the channel handler
+     */
+    private ChannelHandler[] handlers;
+
+    /**
+     * Type of the proxy interface
+     */
+    private Class<?> cls;
+
+    /**
+     * Container Context
+     */
+    private ApplicationContext applicationContext;
+
+    /**
+     * InetSocketAddress
+     */
+    InetSocketAddress address;
+
+    public ClientFactoryBean(String applicationName, String discoveryAdapterName, Class<?> cls) {
+        this.applicationName = applicationName;
+        this.discoveryAdapterName = discoveryAdapterName;
+        this.cls = cls;
+    }
+
+    @Override
+    public Object getObject() throws Exception {
+        this.address = discoveryAdapter.getSocketAddress(applicationName);
+        if (this.address == null) {
+            String[] addressStr = applicationName.split(":");
+            if (addressStr.length < 2) {
+                throw new ConnectionException("Failed to connect to the server because the IP address is invalid. Procedure");
+            }
+            this.address = InetSocketAddress.createUnresolved(addressStr[0], Integer.parseInt(addressStr[1]));
+        }
+        NettyClientPoolHandler handler = new NettyClientPoolHandler(handlers);
+        Client client = NettyClientSupport.getClient(this.address, handler);
+        return NettyProxyCenter.createProxy(client, cls, this.address);
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return cls;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        this.discoveryAdapter = (DiscoveryAdapter) applicationContext.getBean(discoveryAdapterName);
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        if (this.address == null) {
+            return;
+        }
+        NettyClientSupport.closeClient(this.address);
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    public ClientFactoryBean applicationName(String applicationName) {
+        this.applicationName = applicationName;
+        return this;
+    }
+
+    public ClientFactoryBean discoveryAdapterName(String discoveryAdapterName) {
+        this.discoveryAdapterName = discoveryAdapterName;
+        return this;
+    }
+
+    public ClientFactoryBean cls(Class<?> cls) {
+        this.cls = cls;
+        return this;
+    }
+
+    public ClientFactoryBean handlers(ChannelHandler[] handlers) {
+        this.handlers = handlers;
+        return this;
+    }
+
+}

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/support/NettyClientSupport.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/support/NettyClientSupport.java
@@ -98,7 +98,7 @@ public final class NettyClientSupport {
     public static void closeClient(InetSocketAddress address) {
         Client client = clientMap.remove(address);
         try {
-            if (client != null){
+            if (client != null) {
                 client.close();
             }
         } catch (IOException e) {

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/support/NettyClientSupport.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/support/NettyClientSupport.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.hippo4j.rpc.support;
+
+import cn.hippo4j.common.web.exception.IllegalException;
+import cn.hippo4j.rpc.client.Client;
+import cn.hippo4j.rpc.client.ClientConnection;
+import cn.hippo4j.rpc.client.NettyClientConnection;
+import cn.hippo4j.rpc.client.RPCClient;
+import cn.hippo4j.rpc.handler.HandlerManager;
+import cn.hippo4j.rpc.handler.NettyClientPoolHandler;
+import cn.hippo4j.rpc.handler.NettyClientTakeHandler;
+import io.netty.channel.ChannelHandler;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Different from the management of the server side, in order not to waste resources, we pool the
+ * connections of different addresses and turn the client into a one-time resource. If there is no
+ * support from the container, the client is a resource that can be recovered after use. This is
+ * similar to {@link WeakReference}, but the client needs the user to set the life cycle.<br>
+ * <p>
+ * Typically, the client is just a front for the direct connection between the client and the server,
+ * and for any call to succeed, only the {@link ClientConnection} connection is required. In the
+ * presence of a container, it is necessary to keep the client active for a long time, when the
+ * client should be a specific resource in the container, following the resource lifecycle specified
+ * by the container
+ *
+ * @see cn.hippo4j.rpc.client.RPCClient
+ * @see cn.hippo4j.rpc.client.NettyClientConnection
+ * @see NettyServerSupport
+ * @see ClientFactoryBean
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class NettyClientSupport {
+
+    /**
+     * the cache for client
+     */
+    private static final Map<InetSocketAddress, Client> clientMap = new ConcurrentHashMap<>();
+
+    /**
+     * Obtain the client connected to the server through the server address. If the client does not exist, create one
+     *
+     * @param address        the address
+     * @param handlerManager the handlerManager
+     * @return Client
+     */
+    public static Client getClient(InetSocketAddress address, HandlerManager<ChannelHandler> handlerManager) {
+        return clientMap.computeIfAbsent(address, a -> {
+            NettyClientPoolHandler handler = (handlerManager instanceof NettyClientPoolHandler)
+                    ? (NettyClientPoolHandler) handlerManager
+                    : new NettyClientPoolHandler();
+            if (handler.isEmpty()) {
+                handler.addFirst(new NettyClientTakeHandler());
+            }
+            NettyClientConnection connection = new NettyClientConnection(address, handler);
+            return new RPCClient(connection);
+        });
+    }
+
+    /**
+     * Obtain the client connected to the server through the server address. If the client does not exist, create one by default
+     *
+     * @param address the address
+     * @return Client
+     */
+    public static Client getClient(InetSocketAddress address) {
+        return getClient(address, new NettyClientPoolHandler());
+    }
+
+    /**
+     * Close a client connected to a server address. The client may have been closed
+     *
+     * @param address the address
+     */
+    public static void closeClient(InetSocketAddress address) {
+        Client client = clientMap.remove(address);
+        try {
+            if (client != null){
+                client.close();
+            }
+        } catch (IOException e) {
+            throw new IllegalException(e);
+        }
+    }
+}

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/support/ResultHolder.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/support/ResultHolder.java
@@ -46,7 +46,9 @@ public class ResultHolder {
      * @param o   The result
      */
     public static void put(String key, Object o) {
-        log.debug("Write the result, wake up the thread");
+        if (log.isDebugEnabled()) {
+            log.debug("Write the result, wake up the thread");
+        }
         map.put(key, o);
     }
 
@@ -57,7 +59,9 @@ public class ResultHolder {
      * @param t   The Thread
      */
     public static void putThread(String key, Thread t) {
-        log.debug("Write thread, waiting to wake up");
+        if (log.isDebugEnabled()) {
+            log.debug("Write thread, waiting to wake up");
+        }
         threadMap.put(key, t);
     }
 
@@ -67,7 +71,9 @@ public class ResultHolder {
      * @param key Request and response keys
      */
     public static synchronized void wake(String key) {
-        log.debug("The future has been fetched, wake up the thread");
+        if (log.isDebugEnabled()) {
+            log.debug("The future has been fetched, wake up the thread");
+        }
         Thread thread = threadMap.remove(key);
         LockSupport.unpark(thread);
     }
@@ -82,7 +88,9 @@ public class ResultHolder {
      */
     @SuppressWarnings("unchecked")
     public static <T> T get(String key) {
-        log.debug("Get the future");
+        if (log.isDebugEnabled()) {
+            log.debug("Get the future");
+        }
         return (T) map.remove(key);
     }
 

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/client/RPCClientTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/client/RPCClientTest.java
@@ -17,25 +17,25 @@
 
 package cn.hippo4j.rpc.client;
 
+import cn.hippo4j.rpc.discovery.ClassRegistry;
+import cn.hippo4j.rpc.discovery.DefaultInstance;
+import cn.hippo4j.rpc.discovery.Instance;
 import cn.hippo4j.rpc.discovery.ServerPort;
-import cn.hippo4j.rpc.handler.AbstractNettyClientPoolHandler;
+import cn.hippo4j.rpc.handler.NettyClientPoolHandler;
 import cn.hippo4j.rpc.handler.NettyClientTakeHandler;
 import cn.hippo4j.rpc.handler.NettyServerTakeHandler;
 import cn.hippo4j.rpc.model.DefaultRequest;
 import cn.hippo4j.rpc.model.Request;
 import cn.hippo4j.rpc.model.Response;
-import cn.hippo4j.rpc.server.AbstractNettyServerConnection;
+import cn.hippo4j.rpc.server.NettyServerConnection;
 import cn.hippo4j.rpc.server.RPCServer;
 import cn.hippo4j.rpc.server.ServerConnection;
-import cn.hippo4j.rpc.discovery.ClassRegistry;
-import cn.hippo4j.rpc.discovery.DefaultInstance;
-import cn.hippo4j.rpc.discovery.Instance;
 import io.netty.channel.pool.ChannelPoolHandler;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
+import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
 public class RPCClientTest {
@@ -44,6 +44,9 @@ public class RPCClientTest {
     ServerPort port = new TestServerPort();
     ServerPort portTest = new TestPortServerPort();
 
+    /**
+     * This test case can be overridden under the handler and coder packages
+     */
     @Test
     public void connection() throws IOException {
         Class<CallManager> cls = CallManager.class;
@@ -52,49 +55,17 @@ public class RPCClientTest {
         // The mode connection was denied when the server was started on the specified port
         Instance instance = new DefaultInstance();
         NettyServerTakeHandler handler = new NettyServerTakeHandler(instance);
-        ServerConnection connection = new AbstractNettyServerConnection(handler);
-        RPCServer rpcServer = new RPCServer(connection, port);
-        CompletableFuture.runAsync(rpcServer::bind);
-        try {
-            TimeUnit.SECONDS.sleep(3);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-        ChannelPoolHandler channelPoolHandler = new AbstractNettyClientPoolHandler(new NettyClientTakeHandler());
-        NettyClientConnection clientConnection = new NettyClientConnection(host, port, channelPoolHandler);
-        RPCClient rpcClient = new RPCClient(clientConnection);
-        Request request = new DefaultRequest("127.0.0.18888", className, "call", null, null);
-        for (int i = 0; i < 100; i++) {
-            Response response = rpcClient.connection(request);
-            boolean active = rpcClient.isActive();
-            Assert.assertTrue(active);
-            Assert.assertEquals(response.getObj(), 1);
-        }
-        rpcClient.close();
-        rpcServer.close();
-    }
-
-    /**
-     * This test case can be overridden under the handler and coder packages
-     */
-    @Test
-    public void connectionTest() throws IOException {
-        Class<CallManager> cls = CallManager.class;
-        String className = cls.getName();
-        ClassRegistry.put(className, cls);
-        // The mode connection was denied when the server was started on the specified port
-        Instance instance = new DefaultInstance();
-        NettyServerTakeHandler handler = new NettyServerTakeHandler(instance);
-        ServerConnection connection = new AbstractNettyServerConnection(handler);
+        ServerConnection connection = new NettyServerConnection(handler);
         RPCServer rpcServer = new RPCServer(connection, portTest);
-        CompletableFuture.runAsync(rpcServer::bind);
+        rpcServer.bind();
         try {
             TimeUnit.SECONDS.sleep(3);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-        ChannelPoolHandler channelPoolHandler = new AbstractNettyClientPoolHandler(new NettyClientTakeHandler());
-        NettyClientConnection clientConnection = new NettyClientConnection(host, portTest, channelPoolHandler);
+        InetSocketAddress address = InetSocketAddress.createUnresolved(host, portTest.getPort());
+        ChannelPoolHandler channelPoolHandler = new NettyClientPoolHandler(new NettyClientTakeHandler());
+        NettyClientConnection clientConnection = new NettyClientConnection(address, channelPoolHandler);
         RPCClient rpcClient = new RPCClient(clientConnection);
         Class<?>[] classes = new Class<?>[2];
         classes[0] = Integer.class;
@@ -107,6 +78,37 @@ public class RPCClientTest {
         boolean active = rpcClient.isActive();
         Assert.assertTrue(active);
         Assert.assertEquals(response.getObj(), 3);
+        rpcClient.close();
+        rpcServer.close();
+    }
+
+    @Test
+    public void connectionTest() throws IOException {
+        Class<CallManager> cls = CallManager.class;
+        String className = cls.getName();
+        ClassRegistry.put(className, cls);
+        // The mode connection was denied when the server was started on the specified port
+        Instance instance = new DefaultInstance();
+        NettyServerTakeHandler handler = new NettyServerTakeHandler(instance);
+        ServerConnection connection = new NettyServerConnection(handler);
+        RPCServer rpcServer = new RPCServer(connection, port);
+        rpcServer.bind();
+        try {
+            TimeUnit.SECONDS.sleep(3);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        InetSocketAddress address = InetSocketAddress.createUnresolved(host, port.getPort());
+        ChannelPoolHandler channelPoolHandler = new NettyClientPoolHandler(new NettyClientTakeHandler());
+        ClientConnection clientConnection = new NettyClientConnection(address, channelPoolHandler);
+        RPCClient rpcClient = new RPCClient(clientConnection);
+        Request request = new DefaultRequest("127.0.0.18888", className, "call", null, null);
+        for (int i = 0; i < 100; i++) {
+            Response response = rpcClient.connection(request);
+            boolean active = rpcClient.isActive();
+            Assert.assertTrue(active);
+            Assert.assertEquals(response.getObj(), 1);
+        }
         rpcClient.close();
         rpcServer.close();
     }

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/client/RPCClientTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/client/RPCClientTest.java
@@ -17,6 +17,7 @@
 
 package cn.hippo4j.rpc.client;
 
+import cn.hippo4j.common.toolkit.ThreadUtil;
 import cn.hippo4j.rpc.discovery.ClassRegistry;
 import cn.hippo4j.rpc.discovery.DefaultInstance;
 import cn.hippo4j.rpc.discovery.Instance;
@@ -36,7 +37,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.concurrent.TimeUnit;
 
 public class RPCClientTest {
 
@@ -58,10 +58,8 @@ public class RPCClientTest {
         ServerConnection connection = new NettyServerConnection(handler);
         RPCServer rpcServer = new RPCServer(connection, portTest);
         rpcServer.bind();
-        try {
-            TimeUnit.SECONDS.sleep(3);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        while (!rpcServer.isActive()) {
+            ThreadUtil.sleep(100L);
         }
         InetSocketAddress address = InetSocketAddress.createUnresolved(host, portTest.getPort());
         ChannelPoolHandler channelPoolHandler = new NettyClientPoolHandler(new NettyClientTakeHandler());
@@ -93,10 +91,8 @@ public class RPCClientTest {
         ServerConnection connection = new NettyServerConnection(handler);
         RPCServer rpcServer = new RPCServer(connection, port);
         rpcServer.bind();
-        try {
-            TimeUnit.SECONDS.sleep(3);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        while (!rpcServer.isActive()) {
+            ThreadUtil.sleep(100L);
         }
         InetSocketAddress address = InetSocketAddress.createUnresolved(host, port.getPort());
         ChannelPoolHandler channelPoolHandler = new NettyClientPoolHandler(new NettyClientTakeHandler());

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/handler/ConnectHandlerTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/handler/ConnectHandlerTest.java
@@ -17,6 +17,7 @@
 
 package cn.hippo4j.rpc.handler;
 
+import cn.hippo4j.common.toolkit.ThreadUtil;
 import cn.hippo4j.rpc.client.NettyClientConnection;
 import cn.hippo4j.rpc.client.RPCClient;
 import cn.hippo4j.rpc.discovery.*;
@@ -29,7 +30,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.concurrent.TimeUnit;
 
 public class ConnectHandlerTest {
 
@@ -44,10 +44,8 @@ public class ConnectHandlerTest {
         NettyServerConnection connection = new NettyServerConnection(serverHandler);
         RPCServer rpcServer = new RPCServer(connection, port);
         rpcServer.bind();
-        try {
-            TimeUnit.SECONDS.sleep(3);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        while (!rpcServer.isActive()) {
+            ThreadUtil.sleep(100L);
         }
         InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", port.getPort());
         ChannelPoolHandler channelPoolHandler = new NettyClientPoolHandler(new NettyClientTakeHandler());

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/handler/ConnectHandlerTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/handler/ConnectHandlerTest.java
@@ -20,7 +20,7 @@ package cn.hippo4j.rpc.handler;
 import cn.hippo4j.rpc.client.NettyClientConnection;
 import cn.hippo4j.rpc.client.RPCClient;
 import cn.hippo4j.rpc.discovery.*;
-import cn.hippo4j.rpc.server.AbstractNettyServerConnection;
+import cn.hippo4j.rpc.server.NettyServerConnection;
 import cn.hippo4j.rpc.server.RPCServer;
 import cn.hippo4j.rpc.support.NettyProxyCenter;
 import io.netty.channel.pool.ChannelPoolHandler;
@@ -28,7 +28,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
+import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
 public class ConnectHandlerTest {
@@ -38,21 +38,23 @@ public class ConnectHandlerTest {
         // server
         Class<InstanceServerLoader> cls = InstanceServerLoader.class;
         ClassRegistry.put(cls.getName(), cls);
-        ServerPort port = () -> 8891;
+        ServerPort port = () -> 8892;
         Instance instance = new DefaultInstance();
         NettyServerTakeHandler serverHandler = new NettyServerTakeHandler(instance);
-        AbstractNettyServerConnection connection = new AbstractNettyServerConnection(serverHandler);
+        NettyServerConnection connection = new NettyServerConnection(serverHandler);
         RPCServer rpcServer = new RPCServer(connection, port);
-        CompletableFuture.runAsync(rpcServer::bind);
+        rpcServer.bind();
         try {
             TimeUnit.SECONDS.sleep(3);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-        ChannelPoolHandler channelPoolHandler = new AbstractNettyClientPoolHandler(new NettyClientTakeHandler());
-        NettyClientConnection clientConnection = new NettyClientConnection("localhost", port, channelPoolHandler);
+        InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", port.getPort());
+        ChannelPoolHandler channelPoolHandler = new NettyClientPoolHandler(new NettyClientTakeHandler());
+        NettyClientConnection clientConnection = new NettyClientConnection(address, channelPoolHandler);
         RPCClient rpcClient = new RPCClient(clientConnection);
-        InstanceServerLoader loader = NettyProxyCenter.getProxy(rpcClient, cls, "localhost", port);
+
+        InstanceServerLoader loader = NettyProxyCenter.createProxy(rpcClient, cls, address);
         String name = loader.getName();
         Assert.assertEquals("name", name);
         rpcClient.close();

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/handler/NettyClientPoolHandlerTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/handler/NettyClientPoolHandlerTest.java
@@ -28,7 +28,7 @@ public class NettyClientPoolHandlerTest {
         TestHandler handler = new TestHandler();
         long order = 0;
         String name = "Test";
-        AbstractNettyClientPoolHandler poolHandler = new AbstractNettyClientPoolHandler();
+        NettyClientPoolHandler poolHandler = new NettyClientPoolHandler();
         HandlerManager.HandlerEntity<ChannelHandler> entity = poolHandler.getHandlerEntity(order, handler, name);
         Assert.assertEquals(entity.getName(), name);
         Assert.assertEquals(entity.getOrder(), order);
@@ -43,7 +43,7 @@ public class NettyClientPoolHandlerTest {
         TestHandler handler1 = new TestHandler();
         long order1 = 1;
         String name1 = "Test1";
-        AbstractNettyClientPoolHandler poolHandler = new AbstractNettyClientPoolHandler();
+        NettyClientPoolHandler poolHandler = new NettyClientPoolHandler();
         HandlerManager.HandlerEntity<ChannelHandler> entity = poolHandler.getHandlerEntity(order, handler, name);
         HandlerManager.HandlerEntity<ChannelHandler> entity1 = poolHandler.getHandlerEntity(order1, handler1, name1);
         int compare = entity.compareTo(entity1);
@@ -52,7 +52,7 @@ public class NettyClientPoolHandlerTest {
 
     @Test
     public void addLast() {
-        AbstractNettyClientPoolHandler handler = new AbstractNettyClientPoolHandler();
+        NettyClientPoolHandler handler = new NettyClientPoolHandler();
         Assert.assertTrue(handler.isEmpty());
         handler.addLast(new TestHandler());
         Assert.assertFalse(handler.isEmpty());
@@ -60,7 +60,7 @@ public class NettyClientPoolHandlerTest {
 
     @Test
     public void addFirst() {
-        AbstractNettyClientPoolHandler handler = new AbstractNettyClientPoolHandler();
+        NettyClientPoolHandler handler = new NettyClientPoolHandler();
         Assert.assertTrue(handler.isEmpty());
         handler.addFirst(new TestHandler());
         Assert.assertFalse(handler.isEmpty());
@@ -68,7 +68,7 @@ public class NettyClientPoolHandlerTest {
 
     @Test
     public void testAddLast() {
-        AbstractNettyClientPoolHandler handler = new AbstractNettyClientPoolHandler();
+        NettyClientPoolHandler handler = new NettyClientPoolHandler();
         Assert.assertTrue(handler.isEmpty());
         handler.addLast("Test", new TestHandler());
         Assert.assertFalse(handler.isEmpty());
@@ -76,7 +76,7 @@ public class NettyClientPoolHandlerTest {
 
     @Test
     public void testAddFirst() {
-        AbstractNettyClientPoolHandler handler = new AbstractNettyClientPoolHandler();
+        NettyClientPoolHandler handler = new NettyClientPoolHandler();
         Assert.assertTrue(handler.isEmpty());
         handler.addFirst("Test", new TestHandler());
         Assert.assertFalse(handler.isEmpty());

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/server/NettyServerConnectionTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/server/NettyServerConnectionTest.java
@@ -25,7 +25,7 @@ public class NettyServerConnectionTest {
 
     @Test
     public void addLast() {
-        AbstractNettyServerConnection connection = new AbstractNettyServerConnection();
+        NettyServerConnection connection = new NettyServerConnection();
         Assert.assertTrue(connection.isEmpty());
         connection.addLast(new TestHandler());
         Assert.assertFalse(connection.isEmpty());
@@ -33,7 +33,7 @@ public class NettyServerConnectionTest {
 
     @Test
     public void addFirst() {
-        AbstractNettyServerConnection connection = new AbstractNettyServerConnection();
+        NettyServerConnection connection = new NettyServerConnection();
         Assert.assertTrue(connection.isEmpty());
         connection.addFirst(new TestHandler());
         Assert.assertFalse(connection.isEmpty());
@@ -41,7 +41,7 @@ public class NettyServerConnectionTest {
 
     @Test
     public void testAddLast() {
-        AbstractNettyServerConnection connection = new AbstractNettyServerConnection();
+        NettyServerConnection connection = new NettyServerConnection();
         Assert.assertTrue(connection.isEmpty());
         connection.addLast("Test", new TestHandler());
         Assert.assertFalse(connection.isEmpty());
@@ -49,7 +49,7 @@ public class NettyServerConnectionTest {
 
     @Test
     public void testAddFirst() {
-        AbstractNettyServerConnection connection = new AbstractNettyServerConnection();
+        NettyServerConnection connection = new NettyServerConnection();
         Assert.assertTrue(connection.isEmpty());
         connection.addFirst("Test", new TestHandler());
         Assert.assertFalse(connection.isEmpty());

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/server/RPCServerTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/server/RPCServerTest.java
@@ -17,6 +17,7 @@
 
 package cn.hippo4j.rpc.server;
 
+import cn.hippo4j.common.toolkit.ThreadUtil;
 import cn.hippo4j.rpc.discovery.DefaultInstance;
 import cn.hippo4j.rpc.discovery.Instance;
 import cn.hippo4j.rpc.discovery.ServerPort;
@@ -27,7 +28,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 public class RPCServerTest {
 
@@ -41,10 +41,8 @@ public class RPCServerTest {
         ServerConnection connection = new NettyServerConnection(handler);
         RPCServer rpcServer = new RPCServer(connection, port);
         rpcServer.bind();
-        try {
-            TimeUnit.SECONDS.sleep(3);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        while (!rpcServer.isActive()) {
+            ThreadUtil.sleep(100L);
         }
         boolean active = rpcServer.isActive();
         Assert.assertTrue(active);
@@ -62,10 +60,8 @@ public class RPCServerTest {
         ServerConnection connection = new NettyServerConnection(leader, worker, handler);
         RPCServer rpcServer = new RPCServer(connection, portTest);
         rpcServer.bind();
-        try {
-            TimeUnit.SECONDS.sleep(3);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        while (!rpcServer.isActive()) {
+            ThreadUtil.sleep(100L);
         }
         boolean active = rpcServer.isActive();
         Assert.assertTrue(active);

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/server/RPCServerTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/server/RPCServerTest.java
@@ -17,30 +17,30 @@
 
 package cn.hippo4j.rpc.server;
 
-import cn.hippo4j.rpc.discovery.ServerPort;
-import cn.hippo4j.rpc.handler.NettyServerTakeHandler;
 import cn.hippo4j.rpc.discovery.DefaultInstance;
 import cn.hippo4j.rpc.discovery.Instance;
+import cn.hippo4j.rpc.discovery.ServerPort;
+import cn.hippo4j.rpc.handler.NettyServerTakeHandler;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 public class RPCServerTest {
 
     public static ServerPort port = new TestServerPort();
+    public static ServerPort portTest = new ServerPortTest();
 
     @Test
     public void bind() throws IOException {
         Instance instance = new DefaultInstance();
         NettyServerTakeHandler handler = new NettyServerTakeHandler(instance);
-        ServerConnection connection = new AbstractNettyServerConnection(handler);
+        ServerConnection connection = new NettyServerConnection(handler);
         RPCServer rpcServer = new RPCServer(connection, port);
-        CompletableFuture.runAsync(rpcServer::bind);
+        rpcServer.bind();
         try {
             TimeUnit.SECONDS.sleep(3);
         } catch (InterruptedException e) {
@@ -59,22 +59,34 @@ public class RPCServerTest {
         EventLoopGroup leader = new NioEventLoopGroup();
         EventLoopGroup worker = new NioEventLoopGroup();
         NettyServerTakeHandler handler = new NettyServerTakeHandler(instance);
-        ServerConnection connection = new AbstractNettyServerConnection(leader, worker, handler);
-        RPCServer rpcServer = new RPCServer(connection, port);
-        CompletableFuture.runAsync(rpcServer::bind);
+        ServerConnection connection = new NettyServerConnection(leader, worker, handler);
+        RPCServer rpcServer = new RPCServer(connection, portTest);
+        rpcServer.bind();
         try {
             TimeUnit.SECONDS.sleep(3);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
+        boolean active = rpcServer.isActive();
+        Assert.assertTrue(active);
         rpcServer.close();
+        boolean serverActive = rpcServer.isActive();
+        Assert.assertFalse(serverActive);
     }
 
     static class TestServerPort implements ServerPort {
 
         @Override
         public int getPort() {
-            return 8888;
+            return 8893;
+        }
+    }
+
+    static class ServerPortTest implements ServerPort {
+
+        @Override
+        public int getPort() {
+            return 8894;
         }
     }
 }

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyConnectPoolHolderTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyConnectPoolHolderTest.java
@@ -18,7 +18,7 @@
 package cn.hippo4j.rpc.support;
 
 import cn.hippo4j.rpc.discovery.ServerPort;
-import cn.hippo4j.rpc.handler.AbstractNettyClientPoolHandler;
+import cn.hippo4j.rpc.handler.NettyClientPoolHandler;
 import cn.hippo4j.rpc.handler.NettyClientTakeHandler;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
@@ -26,6 +26,8 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.net.InetSocketAddress;
 
 public class NettyConnectPoolHolderTest {
 
@@ -38,34 +40,37 @@ public class NettyConnectPoolHolderTest {
 
     @Test
     public void createPool() {
-        AbstractNettyClientPoolHandler handler = new AbstractNettyClientPoolHandler(new NettyClientTakeHandler());
-        NettyConnectPool pool = new NettyConnectPool(host, port, maxCount, timeout, group, cls, handler);
-        NettyConnectPool connectPool = NettyConnectPoolHolder.getPool(host, port);
+        NettyClientPoolHandler handler = new NettyClientPoolHandler(new NettyClientTakeHandler());
+        InetSocketAddress address = InetSocketAddress.createUnresolved(host, port.getPort());
+        NettyConnectPool pool = new NettyConnectPool(address, maxCount, timeout, group, cls, handler);
+        NettyConnectPool connectPool = NettyConnectPoolHolder.getPool(address);
         Assert.assertEquals(pool, connectPool);
         NettyConnectPoolHolder.clear();
-        NettyConnectPool connectPool1 = NettyConnectPoolHolder.getPool(host, port);
+        NettyConnectPool connectPool1 = NettyConnectPoolHolder.getPool(address);
         Assert.assertNull(connectPool1);
     }
 
     @Test
     public void testGetPool() {
-        AbstractNettyClientPoolHandler handler = new AbstractNettyClientPoolHandler(new NettyClientTakeHandler());
-        NettyConnectPool connectPool = NettyConnectPoolHolder.getPool(host, port, timeout, group, handler);
-        NettyConnectPool connectPool1 = NettyConnectPoolHolder.getPool(host, port);
+        NettyClientPoolHandler handler = new NettyClientPoolHandler(new NettyClientTakeHandler());
+        InetSocketAddress address = InetSocketAddress.createUnresolved(host, port.getPort());
+        NettyConnectPool connectPool = NettyConnectPoolHolder.getPool(address, timeout, group, handler);
+        NettyConnectPool connectPool1 = NettyConnectPoolHolder.getPool(address);
         Assert.assertEquals(connectPool1, connectPool);
         NettyConnectPoolHolder.clear();
-        NettyConnectPool connectPool2 = NettyConnectPoolHolder.getPool(host, port);
+        NettyConnectPool connectPool2 = NettyConnectPoolHolder.getPool(address);
         Assert.assertNull(connectPool2);
     }
 
     @Test
     public void remove() {
-        AbstractNettyClientPoolHandler handler = new AbstractNettyClientPoolHandler(new NettyClientTakeHandler());
-        NettyConnectPool connectPool = NettyConnectPoolHolder.getPool(host, port, timeout, group, handler);
-        NettyConnectPool connectPool1 = NettyConnectPoolHolder.getPool(host, port);
+        NettyClientPoolHandler handler = new NettyClientPoolHandler(new NettyClientTakeHandler());
+        InetSocketAddress address = InetSocketAddress.createUnresolved(host, port.getPort());
+        NettyConnectPool connectPool = NettyConnectPoolHolder.getPool(address, timeout, group, handler);
+        NettyConnectPool connectPool1 = NettyConnectPoolHolder.getPool(address);
         Assert.assertEquals(connectPool1, connectPool);
-        NettyConnectPoolHolder.remove(host, port);
-        NettyConnectPool connectPool2 = NettyConnectPoolHolder.getPool(host, port);
+        NettyConnectPoolHolder.remove(address);
+        NettyConnectPool connectPool2 = NettyConnectPoolHolder.getPool(address);
         Assert.assertNull(connectPool2);
     }
 
@@ -73,7 +78,7 @@ public class NettyConnectPoolHolderTest {
 
         @Override
         public int getPort() {
-            return 8888;
+            return 8895;
         }
     }
 }

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyConnectPoolTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyConnectPoolTest.java
@@ -17,6 +17,7 @@
 
 package cn.hippo4j.rpc.support;
 
+import cn.hippo4j.common.toolkit.ThreadUtil;
 import cn.hippo4j.rpc.discovery.DefaultInstance;
 import cn.hippo4j.rpc.discovery.Instance;
 import cn.hippo4j.rpc.discovery.ServerPort;
@@ -36,7 +37,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.concurrent.TimeUnit;
 
 public class NettyConnectPoolTest {
 
@@ -56,10 +56,8 @@ public class NettyConnectPoolTest {
         RPCServer rpcServer = new RPCServer(connection, port);
         rpcServer.bind();
         // Given the delay in starting the server, wait here
-        try {
-            TimeUnit.SECONDS.sleep(3);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        while (!rpcServer.isActive()) {
+            ThreadUtil.sleep(100L);
         }
         InetSocketAddress address = InetSocketAddress.createUnresolved(host, port.getPort());
         NettyClientPoolHandler poolHandler = new NettyClientPoolHandler(new NettyClientTakeHandler());
@@ -79,10 +77,8 @@ public class NettyConnectPoolTest {
         RPCServer rpcServer = new RPCServer(connection, port);
         rpcServer.bind();
         // Given the delay in starting the server, wait here
-        try {
-            TimeUnit.SECONDS.sleep(3);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        while (!rpcServer.isActive()) {
+            ThreadUtil.sleep(100L);
         }
         InetSocketAddress address = InetSocketAddress.createUnresolved(host, port.getPort());
         NettyClientPoolHandler poolHandler = new NettyClientPoolHandler(new NettyClientTakeHandler());
@@ -101,10 +97,8 @@ public class NettyConnectPoolTest {
         RPCServer rpcServer = new RPCServer(connection, port);
         rpcServer.bind();
         // Given the delay in starting the server, wait here
-        try {
-            TimeUnit.SECONDS.sleep(3);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        while (!rpcServer.isActive()) {
+            ThreadUtil.sleep(100L);
         }
         InetSocketAddress address = InetSocketAddress.createUnresolved(host, port.getPort());
         NettyClientPoolHandler poolHandler = new NettyClientPoolHandler(new NettyClientTakeHandler());

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyConnectPoolTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyConnectPoolTest.java
@@ -20,10 +20,10 @@ package cn.hippo4j.rpc.support;
 import cn.hippo4j.rpc.discovery.DefaultInstance;
 import cn.hippo4j.rpc.discovery.Instance;
 import cn.hippo4j.rpc.discovery.ServerPort;
-import cn.hippo4j.rpc.handler.AbstractNettyClientPoolHandler;
+import cn.hippo4j.rpc.handler.NettyClientPoolHandler;
 import cn.hippo4j.rpc.handler.NettyClientTakeHandler;
 import cn.hippo4j.rpc.handler.NettyServerTakeHandler;
-import cn.hippo4j.rpc.server.AbstractNettyServerConnection;
+import cn.hippo4j.rpc.server.NettyServerConnection;
 import cn.hippo4j.rpc.server.RPCServer;
 import cn.hippo4j.rpc.server.ServerConnection;
 import io.netty.channel.Channel;
@@ -35,7 +35,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
+import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
 public class NettyConnectPoolTest {
@@ -52,17 +52,18 @@ public class NettyConnectPoolTest {
         // The mode connection was denied when the server was started on the specified port
         Instance instance = new DefaultInstance();
         NettyServerTakeHandler handler = new NettyServerTakeHandler(instance);
-        ServerConnection connection = new AbstractNettyServerConnection(handler);
+        ServerConnection connection = new NettyServerConnection(handler);
         RPCServer rpcServer = new RPCServer(connection, port);
-        CompletableFuture.runAsync(rpcServer::bind);
+        rpcServer.bind();
         // Given the delay in starting the server, wait here
         try {
             TimeUnit.SECONDS.sleep(3);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-        AbstractNettyClientPoolHandler poolHandler = new AbstractNettyClientPoolHandler(new NettyClientTakeHandler());
-        NettyConnectPool pool = new NettyConnectPool(host, port, maxCount, timeout, group, cls, poolHandler);
+        InetSocketAddress address = InetSocketAddress.createUnresolved(host, port.getPort());
+        NettyClientPoolHandler poolHandler = new NettyClientPoolHandler(new NettyClientTakeHandler());
+        NettyConnectPool pool = new NettyConnectPool(address, maxCount, timeout, group, cls, poolHandler);
         Channel acquire = pool.acquire(timeout);
         Assert.assertNotNull(acquire);
         pool.release(acquire);
@@ -74,17 +75,18 @@ public class NettyConnectPoolTest {
         // The mode connection was denied when the server was started on the specified port
         Instance instance = new DefaultInstance();
         NettyServerTakeHandler handler = new NettyServerTakeHandler(instance);
-        ServerConnection connection = new AbstractNettyServerConnection(handler);
+        ServerConnection connection = new NettyServerConnection(handler);
         RPCServer rpcServer = new RPCServer(connection, port);
-        CompletableFuture.runAsync(rpcServer::bind);
+        rpcServer.bind();
         // Given the delay in starting the server, wait here
         try {
             TimeUnit.SECONDS.sleep(3);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-        AbstractNettyClientPoolHandler poolHandler = new AbstractNettyClientPoolHandler(new NettyClientTakeHandler());
-        NettyConnectPool pool = new NettyConnectPool(host, port, maxCount, timeout, group, cls, poolHandler);
+        InetSocketAddress address = InetSocketAddress.createUnresolved(host, port.getPort());
+        NettyClientPoolHandler poolHandler = new NettyClientPoolHandler(new NettyClientTakeHandler());
+        NettyConnectPool pool = new NettyConnectPool(address, maxCount, timeout, group, cls, poolHandler);
         Future<Channel> acquire = pool.acquire();
         Assert.assertNotNull(acquire);
         rpcServer.close();
@@ -95,18 +97,18 @@ public class NettyConnectPoolTest {
         // The mode connection was denied when the server was started on the specified port
         Instance instance = new DefaultInstance();
         NettyServerTakeHandler handler = new NettyServerTakeHandler(instance);
-        ServerConnection connection = new AbstractNettyServerConnection(handler);
+        ServerConnection connection = new NettyServerConnection(handler);
         RPCServer rpcServer = new RPCServer(connection, port);
-        CompletableFuture.runAsync(rpcServer::bind);
+        rpcServer.bind();
         // Given the delay in starting the server, wait here
         try {
             TimeUnit.SECONDS.sleep(3);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
-
-        AbstractNettyClientPoolHandler poolHandler = new AbstractNettyClientPoolHandler(new NettyClientTakeHandler());
-        NettyConnectPool pool = new NettyConnectPool(host, port, maxCount, timeout, group, cls, poolHandler);
+        InetSocketAddress address = InetSocketAddress.createUnresolved(host, port.getPort());
+        NettyClientPoolHandler poolHandler = new NettyClientPoolHandler(new NettyClientTakeHandler());
+        NettyConnectPool pool = new NettyConnectPool(address, maxCount, timeout, group, cls, poolHandler);
         Channel acquire = pool.acquire(timeout);
         Assert.assertNotNull(acquire);
         pool.release(acquire);
@@ -118,7 +120,7 @@ public class NettyConnectPoolTest {
 
         @Override
         public int getPort() {
-            return 8888;
+            return 8890;
         }
     }
 }

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyProxyCenterTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyProxyCenterTest.java
@@ -19,10 +19,12 @@ package cn.hippo4j.rpc.support;
 
 import cn.hippo4j.common.web.exception.IllegalException;
 import cn.hippo4j.rpc.discovery.ServerPort;
-import cn.hippo4j.rpc.handler.AbstractNettyClientPoolHandler;
+import cn.hippo4j.rpc.handler.NettyClientPoolHandler;
 import cn.hippo4j.rpc.handler.NettyClientTakeHandler;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.net.InetSocketAddress;
 
 public class NettyProxyCenterTest {
 
@@ -30,15 +32,23 @@ public class NettyProxyCenterTest {
 
     @Test
     public void getProxy() {
-        AbstractNettyClientPoolHandler handler = new AbstractNettyClientPoolHandler(new NettyClientTakeHandler());
-        ProxyInterface localhost = NettyProxyCenter.getProxy(ProxyInterface.class, "localhost", port, handler);
+        InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", port.getPort());
+        NettyClientPoolHandler handler = new NettyClientPoolHandler(new NettyClientTakeHandler());
+        ProxyInterface localhost = NettyProxyCenter.getProxy(ProxyInterface.class, address, handler);
+        Assert.assertNotNull(localhost);
+    }
+
+    @Test
+    public void createProxy() {
+        ProxyInterface localhost = NettyProxyCenter.getProxy(ProxyInterface.class, "localhost:8894");
         Assert.assertNotNull(localhost);
     }
 
     @Test(expected = IllegalException.class)
     public void getProxyTest() {
-        AbstractNettyClientPoolHandler handler = new AbstractNettyClientPoolHandler(new NettyClientTakeHandler());
-        ProxyClass localhost = NettyProxyCenter.getProxy(ProxyClass.class, "localhost", port, handler);
+        InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", port.getPort());
+        NettyClientPoolHandler handler = new NettyClientPoolHandler(new NettyClientTakeHandler());
+        ProxyClass localhost = NettyProxyCenter.getProxy(ProxyClass.class, address, handler);
         Assert.assertNotNull(localhost);
     }
 
@@ -55,7 +65,7 @@ public class NettyProxyCenterTest {
 
         @Override
         public int getPort() {
-            return 8888;
+            return 8894;
         }
     }
 }

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyServerSupportTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyServerSupportTest.java
@@ -17,12 +17,12 @@
 
 package cn.hippo4j.rpc.support;
 
+import cn.hippo4j.common.toolkit.ThreadUtil;
 import cn.hippo4j.rpc.discovery.InstanceServerLoader;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 public class NettyServerSupportTest {
 
@@ -30,10 +30,8 @@ public class NettyServerSupportTest {
     public void bind() throws IOException {
         NettyServerSupport support = new NettyServerSupport(() -> 8891, InstanceServerLoader.class);
         support.bind();
-        try {
-            TimeUnit.SECONDS.sleep(3);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        while (!support.isActive()) {
+            ThreadUtil.sleep(100L);
         }
         Assert.assertTrue(support.isActive());
         support.close();

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyServerSupportTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyServerSupportTest.java
@@ -22,15 +22,14 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 public class NettyServerSupportTest {
 
     @Test
     public void bind() throws IOException {
-        NettyServerSupport support = new NettyServerSupport(() -> 8890, InstanceServerLoader.class);
-        CompletableFuture.runAsync(support::bind);
+        NettyServerSupport support = new NettyServerSupport(() -> 8891, InstanceServerLoader.class);
+        support.bind();
         try {
             TimeUnit.SECONDS.sleep(3);
         } catch (InterruptedException e) {

--- a/hippo4j-rpc/src/test/resources/META-INF/services/cn.hippo4j.rpc.discovery.InstanceServerLoader
+++ b/hippo4j-rpc/src/test/resources/META-INF/services/cn.hippo4j.rpc.discovery.InstanceServerLoader
@@ -1,1 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 cn.hippo4j.rpc.discovery.InstanceServerLoaderImpl


### PR DESCRIPTION
修改ip的格式，使用java提供的InetSocketAddress，对接spring，为被调用的接口添加代理和客户端缓存，考虑到调用方当前的实现，ClientFactoryBean暂不启动，将服务器端的启动修改为异步启动。模式如下：

![无标题-2022-10-21-1103](https://user-images.githubusercontent.com/48643103/201317393-fc6e64bc-a23d-4959-97d0-6a33a428fcee.png)
