### PR TITLE
The RPC module is used to modify the invocation between server modes

### DIFF
--- a/hippo4j-adapter/hippo4j-adapter-base/src/main/java/cn/hippo4j/adapter/base/ThreadPoolAdapterApi.java
+++ b/hippo4j-adapter/hippo4j-adapter-base/src/main/java/cn/hippo4j/adapter/base/ThreadPoolAdapterApi.java
@@ -15,47 +15,27 @@
  * limitations under the License.
  */
 
-package cn.hippo4j.common.model;
+package cn.hippo4j.adapter.base;
 
-import lombok.Data;
-import lombok.experimental.Accessors;
-
-import java.io.Serializable;
+import cn.hippo4j.common.web.base.Result;
 
 /**
- * Thread-pool base info.
+ * Thread-pool adapter api.
  */
-@Data
-@Accessors(chain = true)
-public class ThreadPoolBaseInfo implements Serializable {
+public interface ThreadPoolAdapterApi {
 
     /**
-     * coreSize
+     * Get thread pool information for the third-party framework
+     *
+     * @param requestParameter Third party frame identification and other info
+     * @return thread pool info
      */
-    private Integer coreSize;
+    Result<ThreadPoolAdapterState> getAdapterThreadPool(ThreadPoolAdapterParameter requestParameter);
 
     /**
-     * maximumSize
+     * Example Modify the thread pool information
+     *
+     * @param requestParameter update info
      */
-    private Integer maximumSize;
-
-    /**
-     * queueType
-     */
-    private String queueType;
-
-    /**
-     * queueCapacity
-     */
-    private Integer queueCapacity;
-
-    /**
-     * rejectedName
-     */
-    private String rejectedName;
-
-    /**
-     * keepAliveTime
-     */
-    private Long keepAliveTime;
+    Result<Void> updateAdapterThreadPool(ThreadPoolAdapterParameter requestParameter);
 }

--- a/hippo4j-adapter/hippo4j-adapter-base/src/main/java/cn/hippo4j/adapter/base/ThreadPoolAdapterCacheConfig.java
+++ b/hippo4j-adapter/hippo4j-adapter-base/src/main/java/cn/hippo4j/adapter/base/ThreadPoolAdapterCacheConfig.java
@@ -53,6 +53,11 @@ public class ThreadPoolAdapterCacheConfig {
     private String clientAddress;
 
     /**
+     * Open server address
+     */
+    private String localServerAddress;
+
+    /**
      * Thread-pool adapter states
      */
     private List<ThreadPoolAdapterState> threadPoolAdapterStates;

--- a/hippo4j-adapter/hippo4j-adapter-base/src/main/java/cn/hippo4j/adapter/base/ThreadPoolAdapterParameter.java
+++ b/hippo4j-adapter/hippo4j-adapter-base/src/main/java/cn/hippo4j/adapter/base/ThreadPoolAdapterParameter.java
@@ -19,11 +19,13 @@ package cn.hippo4j.adapter.base;
 
 import lombok.Data;
 
+import java.io.Serializable;
+
 /**
  * Thread pool adapter parameter info.
  */
 @Data
-public class ThreadPoolAdapterParameter {
+public class ThreadPoolAdapterParameter implements Serializable {
 
     /**
      * Mark

--- a/hippo4j-adapter/hippo4j-adapter-base/src/main/java/cn/hippo4j/adapter/base/ThreadPoolAdapterState.java
+++ b/hippo4j-adapter/hippo4j-adapter-base/src/main/java/cn/hippo4j/adapter/base/ThreadPoolAdapterState.java
@@ -19,11 +19,13 @@ package cn.hippo4j.adapter.base;
 
 import lombok.Data;
 
+import java.io.Serializable;
+
 /**
  * Thread pool adapter state info.
  */
 @Data
-public class ThreadPoolAdapterState {
+public class ThreadPoolAdapterState implements Serializable {
 
     /**
      * Thread-pool keu
@@ -44,6 +46,11 @@ public class ThreadPoolAdapterState {
      * Client address
      */
     private String clientAddress;
+
+    /**
+     * Open server address
+     */
+    private String localServerAddress;
 
     /**
      * Core size

--- a/hippo4j-common/src/main/java/cn/hippo4j/common/api/WebThreadPoolApi.java
+++ b/hippo4j-common/src/main/java/cn/hippo4j/common/api/WebThreadPoolApi.java
@@ -15,47 +15,38 @@
  * limitations under the License.
  */
 
-package cn.hippo4j.common.model;
+package cn.hippo4j.common.api;
 
-import lombok.Data;
-import lombok.experimental.Accessors;
-
-import java.io.Serializable;
+import cn.hippo4j.common.model.ThreadPoolBaseInfo;
+import cn.hippo4j.common.model.ThreadPoolParameterInfo;
+import cn.hippo4j.common.model.ThreadPoolRunStateInfo;
+import cn.hippo4j.common.web.base.Result;
 
 /**
- * Thread-pool base info.
+ * Web thread pool api.
  */
-@Data
-@Accessors(chain = true)
-public class ThreadPoolBaseInfo implements Serializable {
+public interface WebThreadPoolApi {
 
     /**
-     * coreSize
+     * Get thread pool information by identifying the mark
+     *
+     * @param mark Third party frame identification
+     * @return thread pool info
      */
-    private Integer coreSize;
+    Result<ThreadPoolBaseInfo> getPoolBaseState(String mark);
 
     /**
-     * maximumSize
+     * Get all thread pool information
+     *
+     * @return thread pool info
      */
-    private Integer maximumSize;
+    Result<ThreadPoolRunStateInfo> getPoolRunState();
 
     /**
-     * queueType
+     * Example Modify the thread pool information
+     *
+     * @param threadPoolParameterInfo update info
      */
-    private String queueType;
+    Result<Void> updateWebThreadPool(ThreadPoolParameterInfo threadPoolParameterInfo);
 
-    /**
-     * queueCapacity
-     */
-    private Integer queueCapacity;
-
-    /**
-     * rejectedName
-     */
-    private String rejectedName;
-
-    /**
-     * keepAliveTime
-     */
-    private Long keepAliveTime;
 }

--- a/hippo4j-common/src/main/java/cn/hippo4j/common/api/WebThreadPoolRunStateApi.java
+++ b/hippo4j-common/src/main/java/cn/hippo4j/common/api/WebThreadPoolRunStateApi.java
@@ -15,47 +15,32 @@
  * limitations under the License.
  */
 
-package cn.hippo4j.common.model;
+package cn.hippo4j.common.api;
 
-import lombok.Data;
-import lombok.experimental.Accessors;
+import cn.hippo4j.common.model.ThreadDetailStateInfo;
+import cn.hippo4j.common.model.ThreadPoolRunStateInfo;
+import cn.hippo4j.common.web.base.Result;
 
-import java.io.Serializable;
+import java.util.List;
 
 /**
- * Thread-pool base info.
+ * Web thread-pool run state api.
  */
-@Data
-@Accessors(chain = true)
-public class ThreadPoolBaseInfo implements Serializable {
+public interface WebThreadPoolRunStateApi {
 
     /**
-     * coreSize
+     * Get the run state info of the web thread pool
+     *
+     * @param threadPoolId the thread pool id
+     * @return the info
      */
-    private Integer coreSize;
+    Result<ThreadPoolRunStateInfo> getPoolRunState(String threadPoolId);
 
     /**
-     * maximumSize
+     * Get the run state detail of the web thread pool
+     *
+     * @param threadPoolId the thread pool id
+     * @return the detail
      */
-    private Integer maximumSize;
-
-    /**
-     * queueType
-     */
-    private String queueType;
-
-    /**
-     * queueCapacity
-     */
-    private Integer queueCapacity;
-
-    /**
-     * rejectedName
-     */
-    private String rejectedName;
-
-    /**
-     * keepAliveTime
-     */
-    private Long keepAliveTime;
+    Result<List<ThreadDetailStateInfo>> getThreadStateDetail(String threadPoolId);
 }

--- a/hippo4j-common/src/main/java/cn/hippo4j/common/model/InstanceInfo.java
+++ b/hippo4j-common/src/main/java/cn/hippo4j/common/model/InstanceInfo.java
@@ -50,6 +50,8 @@ public class InstanceInfo {
 
     private String callBackUrl;
 
+    private String serverUrl;
+
     private String identify;
 
     private String active;

--- a/hippo4j-common/src/main/java/cn/hippo4j/common/model/ThreadDetailStateInfo.java
+++ b/hippo4j-common/src/main/java/cn/hippo4j/common/model/ThreadDetailStateInfo.java
@@ -23,6 +23,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -33,7 +34,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Accessors(chain = true)
-public class ThreadDetailStateInfo {
+public class ThreadDetailStateInfo implements Serializable {
 
     /**
      * threadId

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/handler/NettyClientPoolHandler.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/handler/NettyClientPoolHandler.java
@@ -17,7 +17,6 @@
 
 package cn.hippo4j.rpc.handler;
 
-import cn.hippo4j.rpc.coder.NettyDecoder;
 import cn.hippo4j.rpc.coder.NettyEncoder;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -26,6 +25,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.pool.ChannelPoolHandler;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.serialization.ClassResolvers;
+import io.netty.handler.codec.serialization.ObjectDecoder;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -75,7 +75,9 @@ public class NettyClientPoolHandler extends AbstractNettyHandlerManager implemen
     @Override
     public void channelReleased(Channel ch) {
         ch.writeAndFlush(Unpooled.EMPTY_BUFFER);
-        log.info("The connection buffer has been emptied of data");
+        if (log.isDebugEnabled()) {
+            log.debug("The connection buffer has been emptied of data");
+        }
     }
 
     @Override
@@ -90,7 +92,7 @@ public class NettyClientPoolHandler extends AbstractNettyHandlerManager implemen
                 .setTcpNoDelay(false);
         ChannelPipeline pipeline = ch.pipeline();
         pipeline.addLast(new NettyEncoder());
-        pipeline.addLast(new NettyDecoder(ClassResolvers.cacheDisabled(null)));
+        pipeline.addLast(new ObjectDecoder(Integer.MAX_VALUE, ClassResolvers.cacheDisabled(null)));
         this.handlerEntities.stream()
                 .sorted()
                 .forEach(h -> {

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/handler/NettyServerTakeHandler.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/handler/NettyServerTakeHandler.java
@@ -19,13 +19,13 @@ package cn.hippo4j.rpc.handler;
 
 import cn.hippo4j.common.toolkit.Assert;
 import cn.hippo4j.common.toolkit.ReflectUtil;
-import cn.hippo4j.rpc.process.ActivePostProcess;
-import cn.hippo4j.rpc.process.ActiveProcessChain;
-import cn.hippo4j.rpc.model.Request;
-import cn.hippo4j.rpc.model.DefaultResponse;
-import cn.hippo4j.rpc.model.Response;
 import cn.hippo4j.rpc.discovery.ClassRegistry;
 import cn.hippo4j.rpc.discovery.Instance;
+import cn.hippo4j.rpc.model.DefaultResponse;
+import cn.hippo4j.rpc.model.Request;
+import cn.hippo4j.rpc.model.Response;
+import cn.hippo4j.rpc.process.ActivePostProcess;
+import cn.hippo4j.rpc.process.ActiveProcessChain;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/process/ActiveProcessChain.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/process/ActiveProcessChain.java
@@ -94,7 +94,9 @@ public final class ActiveProcessChain {
             try {
                 handle.afterCompletion(request, response, ex);
             } catch (Throwable e) {
-                log.error("HandlerInterceptor.afterCompletion threw exception", e);
+                if (log.isErrorEnabled()) {
+                    log.error("HandlerInterceptor.afterCompletion threw exception", e);
+                }
             }
         }
     }

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/server/NettyServerConnection.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/server/NettyServerConnection.java
@@ -18,7 +18,6 @@
 package cn.hippo4j.rpc.server;
 
 import cn.hippo4j.common.toolkit.Assert;
-import cn.hippo4j.rpc.coder.NettyDecoder;
 import cn.hippo4j.rpc.coder.NettyEncoder;
 import cn.hippo4j.rpc.discovery.ServerPort;
 import cn.hippo4j.rpc.exception.ConnectionException;
@@ -29,6 +28,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.serialization.ClassResolvers;
+import io.netty.handler.codec.serialization.ObjectDecoder;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
@@ -80,7 +80,7 @@ public class NettyServerConnection extends AbstractNettyHandlerManager implement
                     protected void initChannel(SocketChannel ch) throws Exception {
                         ChannelPipeline pipeline = ch.pipeline();
                         pipeline.addLast(new NettyEncoder());
-                        pipeline.addLast(new NettyDecoder(ClassResolvers.cacheDisabled(null)));
+                        pipeline.addLast(new ObjectDecoder(Integer.MAX_VALUE, ClassResolvers.cacheDisabled(null)));
                         handlerEntities.stream()
                                 .sorted()
                                 .forEach(h -> {
@@ -95,7 +95,9 @@ public class NettyServerConnection extends AbstractNettyHandlerManager implement
         try {
             this.future = server.bind(port.getPort()).sync();
             this.channel = this.future.channel();
-            log.info("The server is started and can receive requests. The listening port is {}", port.getPort());
+            if (log.isDebugEnabled()) {
+                log.debug("The server is started and can receive requests. The listening port is {}", port.getPort());
+            }
             this.port = port;
             this.future.channel().closeFuture().sync();
         } catch (InterruptedException ex) {
@@ -112,7 +114,9 @@ public class NettyServerConnection extends AbstractNettyHandlerManager implement
         leader.shutdownGracefully();
         worker.shutdownGracefully();
         this.future.channel().close();
-        log.info("The server is shut down and no more requests are received. The release port is {}", port.getPort());
+        if (log.isDebugEnabled()) {
+            log.debug("The server is shut down and no more requests are received. The release port is {}", port.getPort());
+        }
     }
 
     @Override

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/support/NettyConnectPool.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/support/NettyConnectPool.java
@@ -58,7 +58,9 @@ public class NettyConnectPool {
         this.handler = handler;
         this.pool = new FixedChannelPool(bootstrap, handler, healthCheck, acquireTimeoutAction,
                 timeout, maxConnect, maxPendingAcquires, true, true);
-        log.info("The connection pool is established with the connection target {}:{}", address.getHostName(), address.getPort());
+        if (log.isDebugEnabled()) {
+            log.info("The connection pool is established with the connection target {}:{}", address.getHostName(), address.getPort());
+        }
         NettyConnectPoolHolder.createPool(address, this);
     }
 

--- a/hippo4j-server/hippo4j-config/pom.xml
+++ b/hippo4j-server/hippo4j-config/pom.xml
@@ -20,6 +20,11 @@
             <version>${revision}</version>
         </dependency>
         <dependency>
+            <groupId>cn.hippo4j</groupId>
+            <artifactId>hippo4j-rpc</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/hippo4j-server/hippo4j-config/src/main/java/cn/hippo4j/config/service/biz/impl/AdapterThreadPoolConfigModificationVerifyServiceImpl.java
+++ b/hippo4j-server/hippo4j-config/src/main/java/cn/hippo4j/config/service/biz/impl/AdapterThreadPoolConfigModificationVerifyServiceImpl.java
@@ -18,9 +18,6 @@
 package cn.hippo4j.config.service.biz.impl;
 
 import cn.hippo4j.common.constant.ConfigModifyTypeConstants;
-import cn.hippo4j.common.toolkit.StringUtil;
-import cn.hippo4j.common.toolkit.http.HttpUtil;
-import cn.hippo4j.config.model.biz.threadpool.ConfigModifyVerifyReqDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -36,11 +33,4 @@ public class AdapterThreadPoolConfigModificationVerifyServiceImpl extends Abstra
         return ConfigModifyTypeConstants.ADAPTER_THREAD_POOL;
     }
 
-    @Override
-    protected void updateThreadPoolParameter(ConfigModifyVerifyReqDTO reqDTO) {
-        for (String each : getClientAddress(reqDTO)) {
-            String urlString = StringUtil.newBuilder("http://", each, "/adapter/thread-pool/update");
-            HttpUtil.post(urlString, reqDTO);
-        }
-    }
 }

--- a/hippo4j-server/hippo4j-config/src/main/java/cn/hippo4j/config/service/biz/impl/WebThreadPoolConfigModificationVerifyServiceImpl.java
+++ b/hippo4j-server/hippo4j-config/src/main/java/cn/hippo4j/config/service/biz/impl/WebThreadPoolConfigModificationVerifyServiceImpl.java
@@ -18,9 +18,6 @@
 package cn.hippo4j.config.service.biz.impl;
 
 import cn.hippo4j.common.constant.ConfigModifyTypeConstants;
-import cn.hippo4j.common.toolkit.StringUtil;
-import cn.hippo4j.common.toolkit.http.HttpUtil;
-import cn.hippo4j.config.model.biz.threadpool.ConfigModifyVerifyReqDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -36,11 +33,4 @@ public class WebThreadPoolConfigModificationVerifyServiceImpl extends AbstractCo
         return ConfigModifyTypeConstants.WEB_THREAD_POOL;
     }
 
-    @Override
-    protected void updateThreadPoolParameter(ConfigModifyVerifyReqDTO reqDTO) {
-        for (String each : getClientAddress(reqDTO)) {
-            String urlString = StringUtil.newBuilder("http://", each, "/web/update/pool");
-            HttpUtil.post(urlString, reqDTO);
-        }
-    }
 }

--- a/hippo4j-server/hippo4j-console/src/main/java/cn/hippo4j/console/controller/ThreadPoolAdapterController.java
+++ b/hippo4j-server/hippo4j-console/src/main/java/cn/hippo4j/console/controller/ThreadPoolAdapterController.java
@@ -17,18 +17,11 @@
 
 package cn.hippo4j.console.controller;
 
-import cn.hippo4j.common.constant.ConfigModifyTypeConstants;
-import cn.hippo4j.common.toolkit.BeanUtil;
-import cn.hippo4j.common.toolkit.StringUtil;
-import cn.hippo4j.common.toolkit.UserContext;
-import cn.hippo4j.common.toolkit.http.HttpUtil;
 import cn.hippo4j.common.web.base.Result;
 import cn.hippo4j.common.web.base.Results;
 import cn.hippo4j.config.model.biz.adapter.ThreadPoolAdapterReqDTO;
 import cn.hippo4j.config.model.biz.adapter.ThreadPoolAdapterRespDTO;
-import cn.hippo4j.config.model.biz.threadpool.ConfigModifySaveReqDTO;
 import cn.hippo4j.config.service.ThreadPoolAdapterService;
-import cn.hippo4j.config.verify.ConfigModificationVerifyServiceChoose;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,8 +42,6 @@ public class ThreadPoolAdapterController {
 
     private final ThreadPoolAdapterService threadPoolAdapterService;
 
-    private final ConfigModificationVerifyServiceChoose configModificationVerifyServiceChoose;
-
     @GetMapping(REGISTER_ADAPTER_BASE_PATH + "/query")
     public Result<List<ThreadPoolAdapterRespDTO>> queryAdapterThreadPool(ThreadPoolAdapterReqDTO requestParameter) {
         List<ThreadPoolAdapterRespDTO> result = threadPoolAdapterService.query(requestParameter);
@@ -65,20 +56,7 @@ public class ThreadPoolAdapterController {
 
     @PostMapping(REGISTER_ADAPTER_BASE_PATH + "/update")
     public Result<Void> updateAdapterThreadPool(@RequestBody ThreadPoolAdapterReqDTO requestParameter) {
-        if (UserContext.getUserRole().equals("ROLE_ADMIN")) {
-            for (String each : requestParameter.getClientAddressList()) {
-                String urlString = StringUtil.newBuilder("http://", each, "/adapter/thread-pool/update");
-                HttpUtil.post(urlString, requestParameter);
-            }
-        } else {
-            ConfigModifySaveReqDTO modifySaveReqDTO = BeanUtil.convert(requestParameter, ConfigModifySaveReqDTO.class);
-            modifySaveReqDTO.setModifyUser(UserContext.getUserName());
-            modifySaveReqDTO.setTenantId(requestParameter.getTenant());
-            modifySaveReqDTO.setItemId(requestParameter.getItem());
-            modifySaveReqDTO.setTpId(requestParameter.getThreadPoolKey());
-            modifySaveReqDTO.setType(ConfigModifyTypeConstants.ADAPTER_THREAD_POOL);
-            configModificationVerifyServiceChoose.choose(modifySaveReqDTO.getType()).saveConfigModifyApplication(modifySaveReqDTO);
-        }
+        threadPoolAdapterService.updateThreadPool(requestParameter);
         return Results.success();
     }
 

--- a/hippo4j-server/hippo4j-console/src/main/java/cn/hippo4j/console/controller/ThreadPoolController.java
+++ b/hippo4j-server/hippo4j-console/src/main/java/cn/hippo4j/console/controller/ThreadPoolController.java
@@ -17,23 +17,21 @@
 
 package cn.hippo4j.console.controller;
 
+import cn.hippo4j.common.api.WebThreadPoolApi;
+import cn.hippo4j.common.api.WebThreadPoolRunStateApi;
 import cn.hippo4j.common.constant.ConfigModifyTypeConstants;
 import cn.hippo4j.common.constant.Constants;
 import cn.hippo4j.common.model.InstanceInfo;
+import cn.hippo4j.common.model.ThreadPoolParameterInfo;
 import cn.hippo4j.common.toolkit.BeanUtil;
 import cn.hippo4j.common.toolkit.CollectionUtil;
 import cn.hippo4j.common.toolkit.StringUtil;
 import cn.hippo4j.common.toolkit.UserContext;
-import cn.hippo4j.common.toolkit.http.HttpUtil;
 import cn.hippo4j.common.web.base.Result;
 import cn.hippo4j.common.web.base.Results;
 import cn.hippo4j.common.web.exception.ErrorCodeEnum;
 import cn.hippo4j.config.model.CacheItem;
-import cn.hippo4j.config.model.biz.threadpool.ConfigModifySaveReqDTO;
-import cn.hippo4j.config.model.biz.threadpool.ThreadPoolDelReqDTO;
-import cn.hippo4j.config.model.biz.threadpool.ThreadPoolQueryReqDTO;
-import cn.hippo4j.config.model.biz.threadpool.ThreadPoolRespDTO;
-import cn.hippo4j.config.model.biz.threadpool.ThreadPoolSaveOrUpdateReqDTO;
+import cn.hippo4j.config.model.biz.threadpool.*;
 import cn.hippo4j.config.service.ConfigCacheService;
 import cn.hippo4j.config.service.biz.ThreadPoolService;
 import cn.hippo4j.config.verify.ConfigModificationVerifyServiceChoose;
@@ -42,17 +40,11 @@ import cn.hippo4j.console.model.WebThreadPoolReqDTO;
 import cn.hippo4j.console.model.WebThreadPoolRespDTO;
 import cn.hippo4j.discovery.core.BaseInstanceRegistry;
 import cn.hippo4j.discovery.core.Lease;
+import cn.hippo4j.rpc.support.NettyProxyCenter;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +67,9 @@ public class ThreadPoolController {
 
     private final ConfigModificationVerifyServiceChoose configModificationVerifyServiceChoose;
 
-    private static final String HTTP = "http://";
+    private static final Class<WebThreadPoolRunStateApi> STATE_API_CLASS = WebThreadPoolRunStateApi.class;
+
+    private static final Class<WebThreadPoolApi> POOL_API_CLASS = WebThreadPoolApi.class;
 
     @PostMapping("/query/page")
     public Result<IPage<ThreadPoolRespDTO>> queryNameSpacePage(@RequestBody ThreadPoolQueryReqDTO reqDTO) {
@@ -122,15 +116,15 @@ public class ThreadPoolController {
     @GetMapping("/run/state/{tpId}")
     public Result runState(@PathVariable("tpId") String tpId,
                            @RequestParam(value = "clientAddress") String clientAddress) {
-        String urlString = StringUtil.newBuilder(HTTP, clientAddress, "/run/state/", tpId);
-        return HttpUtil.get(urlString, Result.class);
+        WebThreadPoolRunStateApi threadPoolRunStateApi = NettyProxyCenter.getProxy(STATE_API_CLASS, clientAddress);
+        return threadPoolRunStateApi.getPoolRunState(tpId);
     }
 
     @GetMapping("/run/thread/state/{tpId}")
     public Result runThreadState(@PathVariable("tpId") String tpId,
                                  @RequestParam(value = "clientAddress") String clientAddress) {
-        String urlString = StringUtil.newBuilder(HTTP, clientAddress, "/run/thread/state/", tpId);
-        return HttpUtil.get(urlString, Result.class);
+        WebThreadPoolRunStateApi threadPoolRunStateApi = NettyProxyCenter.getProxy(STATE_API_CLASS, clientAddress);
+        return threadPoolRunStateApi.getThreadStateDetail(tpId);
     }
 
     @GetMapping("/list/client/instance/{itemId}")
@@ -145,7 +139,7 @@ public class ThreadPoolController {
         for (Lease<InstanceInfo> each : leases) {
             Result poolBaseState;
             try {
-                poolBaseState = getPoolBaseState(mark, each.getHolder().getCallBackUrl());
+                poolBaseState = getPoolBaseState(mark, each.getHolder().getServerUrl());
             } catch (Throwable ignored) {
                 continue;
             }
@@ -158,7 +152,7 @@ public class ThreadPoolController {
             result.setTenantId(each.getHolder().getGroupKey().split("[+]")[1]);
             result.setActive(each.getHolder().getActive());
             result.setIdentify(each.getHolder().getIdentify());
-            result.setClientAddress(each.getHolder().getCallBackUrl());
+            result.setClientAddress(each.getHolder().getServerUrl());
             returnThreadPool.add(result);
         }
         return Results.success(returnThreadPool);
@@ -167,22 +161,23 @@ public class ThreadPoolController {
     @GetMapping("/web/base/info")
     public Result getPoolBaseState(@RequestParam(value = "mark") String mark,
                                    @RequestParam(value = "clientAddress") String clientAddress) {
-        String urlString = StringUtil.newBuilder(HTTP, clientAddress, "/web/base/info", "?mark=", mark);
-        return HttpUtil.get(urlString, Result.class);
+        WebThreadPoolApi threadPoolApi = NettyProxyCenter.getProxy(POOL_API_CLASS, clientAddress);
+        return threadPoolApi.getPoolBaseState(mark);
     }
 
     @GetMapping("/web/run/state")
     public Result getPoolRunState(@RequestParam(value = "clientAddress") String clientAddress) {
-        String urlString = StringUtil.newBuilder(HTTP, clientAddress, "/web/run/state");
-        return HttpUtil.get(urlString, Result.class);
+        WebThreadPoolApi threadPoolApi = NettyProxyCenter.getProxy(POOL_API_CLASS, clientAddress);
+        return threadPoolApi.getPoolRunState();
     }
 
     @PostMapping("/web/update/pool")
     public Result<Void> updateWebThreadPool(@RequestBody WebThreadPoolReqDTO requestParam) {
         if (UserContext.getUserRole().equals("ROLE_ADMIN")) {
             for (String each : requestParam.getClientAddressList()) {
-                String urlString = StringUtil.newBuilder(HTTP, each, "/web/update/pool");
-                HttpUtil.post(urlString, requestParam);
+                WebThreadPoolApi threadPoolApi = NettyProxyCenter.getProxy(POOL_API_CLASS, each);
+                ThreadPoolParameterInfo parameterInfo = BeanUtil.convert(requestParam, ThreadPoolParameterInfo.class);
+                threadPoolApi.updateWebThreadPool(parameterInfo);
             }
         } else {
             ConfigModifySaveReqDTO modifySaveReqDTO = BeanUtil.convert(requestParam, ConfigModifySaveReqDTO.class);
@@ -206,9 +201,9 @@ public class ThreadPoolController {
         String groupKey = getGroupKey(tpId, itemTenantKey);
         Map<String, CacheItem> content = ConfigCacheService.getContent(groupKey);
         Map<String, String> activeMap =
-                leases.stream().map(each -> each.getHolder()).filter(each -> StringUtil.isNotBlank(each.getActive()))
+                leases.stream().map(Lease::getHolder).filter(each -> StringUtil.isNotBlank(each.getActive()))
                         .collect(Collectors.toMap(InstanceInfo::getIdentify, InstanceInfo::getActive));
-        Map<String, String> clientBasePathMap = leases.stream().map(each -> each.getHolder())
+        Map<String, String> clientBasePathMap = leases.stream().map(Lease::getHolder)
                 .filter(each -> StringUtil.isNotBlank(each.getClientBasePath()))
                 .collect(Collectors.toMap(InstanceInfo::getIdentify, InstanceInfo::getClientBasePath));
         List<ThreadPoolInstanceInfo> returnThreadPool = new ArrayList<>();

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/pom.xml
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/pom.xml
@@ -34,6 +34,11 @@
             <version>${revision}</version>
         </dependency>
         <dependency>
+            <groupId>cn.hippo4j</groupId>
+            <artifactId>hippo4j-rpc</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/config/BootstrapProperties.java
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/config/BootstrapProperties.java
@@ -55,6 +55,11 @@ public class BootstrapProperties implements BootstrapPropertiesInterface {
     private String nettyServerPort;
 
     /**
+     * The service port that is open to the outside world, The default value is 16691
+     */
+    private Integer localServerPort;
+
+    /**
      * Report type
      */
     private String reportType;

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/config/DynamicThreadPoolAutoConfiguration.java
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/config/DynamicThreadPoolAutoConfiguration.java
@@ -82,7 +82,8 @@ import org.springframework.core.env.ConfigurableEnvironment;
 @ConditionalOnBean(MarkerConfiguration.Marker.class)
 @EnableConfigurationProperties(BootstrapProperties.class)
 @ConditionalOnProperty(prefix = BootstrapProperties.PREFIX, value = "enable", matchIfMissing = true, havingValue = "true")
-@ImportAutoConfiguration({WebAdapterConfiguration.class, NettyClientConfiguration.class, DiscoveryConfiguration.class, MessageConfiguration.class, UtilAutoConfiguration.class})
+@ImportAutoConfiguration({WebAdapterConfiguration.class, NettyClientConfiguration.class, DiscoveryConfiguration.class, MessageConfiguration.class, UtilAutoConfiguration.class,
+        NettyServerConfiguration.class})
 public class DynamicThreadPoolAutoConfiguration {
 
     private final BootstrapProperties properties;

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/config/NettyServerConfiguration.java
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/config/NettyServerConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.hippo4j.springboot.starter.config;
+
+import cn.hippo4j.adapter.base.ThreadPoolAdapterApi;
+import cn.hippo4j.common.api.WebThreadPoolApi;
+import cn.hippo4j.common.api.WebThreadPoolRunStateApi;
+import cn.hippo4j.rpc.discovery.ServerPort;
+import cn.hippo4j.rpc.discovery.SpringContextInstance;
+import cn.hippo4j.rpc.handler.NettyServerTakeHandler;
+import cn.hippo4j.rpc.server.NettyServerConnection;
+import cn.hippo4j.rpc.server.Server;
+import cn.hippo4j.rpc.support.NettyServerSupport;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NettyServerConfiguration implements ApplicationRunner, EnvironmentAware {
+
+    Environment environment;
+
+    private static final Class<?>[] classes = {
+            WebThreadPoolApi.class,
+            ThreadPoolAdapterApi.class,
+            WebThreadPoolRunStateApi.class
+    };
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        Integer port = environment.getProperty("spring.dynamic.thread-pool.local-server-port", Integer.class);
+        ServerPort serverPort = () -> port == null ? 16691 : port;
+        NettyServerTakeHandler handler = new NettyServerTakeHandler(new SpringContextInstance());
+        try (
+                NettyServerConnection connection = new NettyServerConnection(handler);
+                Server server = new NettyServerSupport(serverPort, connection, classes)) {
+            server.bind();
+        }
+    }
+
+    @Override
+    public void setEnvironment(Environment environment) {
+        this.environment = environment;
+    }
+}

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/controller/ThreadPoolAdapterController.java
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/controller/ThreadPoolAdapterController.java
@@ -18,6 +18,7 @@
 package cn.hippo4j.springboot.starter.controller;
 
 import cn.hippo4j.adapter.base.ThreadPoolAdapter;
+import cn.hippo4j.adapter.base.ThreadPoolAdapterApi;
 import cn.hippo4j.adapter.base.ThreadPoolAdapterParameter;
 import cn.hippo4j.adapter.base.ThreadPoolAdapterState;
 import cn.hippo4j.common.api.ClientNetworkService;
@@ -31,10 +32,7 @@ import cn.hippo4j.springboot.starter.toolkit.CloudCommonIdUtil;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Optional;
 
@@ -44,15 +42,16 @@ import static cn.hippo4j.adapter.base.ThreadPoolAdapterBeanContainer.THREAD_POOL
  * Thread-pool adapter controller.
  */
 @Slf4j
-@RestController
+// @RestController
 @AllArgsConstructor
-public class ThreadPoolAdapterController {
+public class ThreadPoolAdapterController implements ThreadPoolAdapterApi {
 
     private final ConfigurableEnvironment environment;
 
     private final InetUtils hippo4JInetUtils;
 
-    @GetMapping("/adapter/thread-pool/info")
+    @Override
+    // @GetMapping("/adapter/thread-pool/info")
     public Result<ThreadPoolAdapterState> getAdapterThreadPool(ThreadPoolAdapterParameter requestParameter) {
         ThreadPoolAdapter threadPoolAdapter = THREAD_POOL_ADAPTER_BEAN_CONTAINER.get(requestParameter.getMark());
         ThreadPoolAdapterState result = Optional.ofNullable(threadPoolAdapter).map(each -> {
@@ -74,7 +73,8 @@ public class ThreadPoolAdapterController {
         return Results.success(result);
     }
 
-    @PostMapping("/adapter/thread-pool/update")
+    @Override
+    // @PostMapping("/adapter/thread-pool/update")
     public Result<Void> updateAdapterThreadPool(@RequestBody ThreadPoolAdapterParameter requestParameter) {
         log.info("[{}] Change third-party thread pool data. key: {}, coreSize: {}, maximumSize: {}",
                 requestParameter.getMark(), requestParameter.getThreadPoolKey(), requestParameter.getCorePoolSize(), requestParameter.getMaximumPoolSize());

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/controller/WebThreadPoolController.java
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/controller/WebThreadPoolController.java
@@ -19,6 +19,7 @@ package cn.hippo4j.springboot.starter.controller;
 
 import cn.hippo4j.adapter.web.WebThreadPoolHandlerChoose;
 import cn.hippo4j.adapter.web.WebThreadPoolService;
+import cn.hippo4j.common.api.WebThreadPoolApi;
 import cn.hippo4j.common.model.ThreadPoolBaseInfo;
 import cn.hippo4j.common.model.ThreadPoolParameterInfo;
 import cn.hippo4j.common.model.ThreadPoolRunStateInfo;
@@ -33,13 +34,14 @@ import org.springframework.web.bind.annotation.*;
  * <p> At present, only Tomcat is well supported, and other web containers need to be improved.
  */
 @CrossOrigin
-@RestController
+// @RestController
 @AllArgsConstructor
-public class WebThreadPoolController {
+public class WebThreadPoolController implements WebThreadPoolApi {
 
     private final WebThreadPoolHandlerChoose webThreadPoolServiceChoose;
 
-    @GetMapping("/web/base/info")
+    @Override
+    // @GetMapping("/web/base/info")
     public Result<ThreadPoolBaseInfo> getPoolBaseState(@RequestParam(value = "mark") String mark) {
         WebThreadPoolService webThreadPoolService = webThreadPoolServiceChoose.choose();
         if (webThreadPoolService != null && webThreadPoolService.getClass().getSimpleName().contains(mark)) {
@@ -48,13 +50,15 @@ public class WebThreadPoolController {
         return Results.success(null);
     }
 
-    @GetMapping("/web/run/state")
+    @Override
+    // @GetMapping("/web/run/state")
     public Result<ThreadPoolRunStateInfo> getPoolRunState() {
         ThreadPoolRunStateInfo result = webThreadPoolServiceChoose.choose().getWebRunStateInfo();
         return Results.success(result);
     }
 
-    @PostMapping("/web/update/pool")
+    @Override
+    // @PostMapping("/web/update/pool")
     public Result<Void> updateWebThreadPool(@RequestBody ThreadPoolParameterInfo threadPoolParameterInfo) {
         webThreadPoolServiceChoose.choose().updateWebThreadPool(threadPoolParameterInfo);
         return Results.success();

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/controller/WebThreadPoolRunStateController.java
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/controller/WebThreadPoolRunStateController.java
@@ -18,16 +18,15 @@
 package cn.hippo4j.springboot.starter.controller;
 
 import cn.hippo4j.common.api.ThreadDetailState;
-import cn.hippo4j.common.model.ThreadPoolRunStateInfo;
+import cn.hippo4j.common.api.WebThreadPoolRunStateApi;
 import cn.hippo4j.common.model.ThreadDetailStateInfo;
+import cn.hippo4j.common.model.ThreadPoolRunStateInfo;
 import cn.hippo4j.common.web.base.Result;
 import cn.hippo4j.common.web.base.Results;
 import cn.hippo4j.core.executor.state.ThreadPoolRunStateHandler;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -35,21 +34,23 @@ import java.util.List;
  * Web thread-pool run state controller.
  */
 @CrossOrigin
-@RestController
+// @RestController
 @AllArgsConstructor
-public class WebThreadPoolRunStateController {
+public class WebThreadPoolRunStateController implements WebThreadPoolRunStateApi {
 
     private final ThreadPoolRunStateHandler threadPoolRunStateHandler;
 
     private final ThreadDetailState threadDetailState;
 
-    @GetMapping("/run/state/{threadPoolId}")
+    @Override
+    // @GetMapping("/run/state/{threadPoolId}")
     public Result<ThreadPoolRunStateInfo> getPoolRunState(@PathVariable("threadPoolId") String threadPoolId) {
         ThreadPoolRunStateInfo result = threadPoolRunStateHandler.getPoolRunState(threadPoolId);
         return Results.success(result);
     }
 
-    @GetMapping("/run/thread/state/{threadPoolId}")
+    @Override
+    // @GetMapping("/run/thread/state/{threadPoolId}")
     public Result<List<ThreadDetailStateInfo>> getThreadStateDetail(@PathVariable("threadPoolId") String threadPoolId) {
         List<ThreadDetailStateInfo> result = threadDetailState.getThreadDetailStateInfo(threadPoolId);
         return Results.success(result);

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/core/ThreadPoolAdapterRegister.java
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/core/ThreadPoolAdapterRegister.java
@@ -79,6 +79,8 @@ public class ThreadPoolAdapterRegister implements ApplicationRunner, ThreadPoolA
             String clientAddress = CloudCommonIdUtil.getClientIpPort(environment, hippo4JInetUtils);
             cacheConfig.setClientAddress(clientAddress);
             cacheConfig.setThreadPoolAdapterStates(threadPoolStates);
+            String localServerAddress = CloudCommonIdUtil.getLocalServerIpPort(environment, hippo4JInetUtils);
+            cacheConfig.setLocalServerAddress(localServerAddress);
             adapterCacheConfigList.add(cacheConfig);
         }
         return adapterCacheConfigList;

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/provider/InstanceInfoProviderFactory.java
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/provider/InstanceInfoProviderFactory.java
@@ -21,6 +21,7 @@ import cn.hippo4j.common.api.ClientNetworkService;
 import cn.hippo4j.common.model.InstanceInfo;
 import cn.hippo4j.common.spi.DynamicThreadPoolServiceLoader;
 import cn.hippo4j.common.toolkit.ContentUtil;
+import cn.hippo4j.common.toolkit.StringUtil;
 import cn.hippo4j.core.toolkit.IdentifyUtil;
 import cn.hippo4j.core.toolkit.inet.InetUtils;
 import cn.hippo4j.springboot.starter.config.BootstrapProperties;
@@ -58,12 +59,12 @@ public final class InstanceInfoProviderFactory {
         String namespace = bootstrapProperties.getNamespace();
         String itemId = bootstrapProperties.getItemId();
         String port = environment.getProperty("server.port", "8080");
+        String serverPort = environment.getProperty("spring.dynamic.thread-pool.local-server-port", "16691");
         String applicationName = environment.getProperty("spring.dynamic.thread-pool.item-id");
         String active = environment.getProperty("spring.profiles.active", "UNKNOWN");
         InstanceInfo instanceInfo = new InstanceInfo();
         String instanceId = CloudCommonIdUtil.getDefaultInstanceId(environment, inetUtils);
-        instanceId = new StringBuilder()
-                .append(instanceId).append(IDENTIFY_SLICER_SYMBOL).append(CLIENT_IDENTIFICATION_VALUE).toString();
+        instanceId = instanceId + IDENTIFY_SLICER_SYMBOL + CLIENT_IDENTIFICATION_VALUE;
         String contextPath = environment.getProperty("server.servlet.context-path", "");
         instanceInfo.setInstanceId(instanceId)
                 .setIpApplicationName(CloudCommonIdUtil.getIpApplicationName(environment, inetUtils))
@@ -71,10 +72,19 @@ public final class InstanceInfoProviderFactory {
                 .setPort(port).setClientBasePath(contextPath).setGroupKey(ContentUtil.getGroupKey(itemId, namespace));
         String[] customerNetwork = DynamicThreadPoolServiceLoader.getSingletonServiceInstances(ClientNetworkService.class)
                 .stream().findFirst().map(each -> each.getNetworkIpPort(environment)).orElse(null);
-        String callBackUrl = new StringBuilder().append(Optional.ofNullable(customerNetwork).map(each -> each[0]).orElse(instanceInfo.getHostName())).append(":")
-                .append(Optional.ofNullable(customerNetwork).map(each -> each[1]).orElse(port)).append(instanceInfo.getClientBasePath())
-                .toString();
+
+        String callBackUrl = StringUtil.newBuilder(
+                Optional.ofNullable(customerNetwork).map(each -> each[0]).orElse(instanceInfo.getHostName()),
+                ":",
+                Optional.ofNullable(customerNetwork).map(each -> each[1]).orElse(port),
+                instanceInfo.getClientBasePath());
+        String serverUrl = StringUtil.newBuilder(
+                Optional.ofNullable(customerNetwork).map(each -> each[0]).orElse(instanceInfo.getHostName()),
+                ":",
+                serverPort,
+                instanceInfo.getClientBasePath());
         instanceInfo.setCallBackUrl(callBackUrl);
+        instanceInfo.setServerUrl(serverUrl);
         String identify = IdentifyUtil.generate(environment, inetUtils);
         instanceInfo.setIdentify(identify);
         instanceInfo.setActive(active.toUpperCase());

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/toolkit/CloudCommonIdUtil.java
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/java/cn/hippo4j/springboot/starter/toolkit/CloudCommonIdUtil.java
@@ -45,6 +45,19 @@ public class CloudCommonIdUtil {
     }
 
     /**
+     * Get local server ip port.
+     *
+     * @param resolver  resolver
+     * @param inetUtils inet utils
+     * @return ip and port
+     */
+    public static String getLocalServerIpPort(PropertyResolver resolver, InetUtils inetUtils) {
+        String hostname = inetUtils.findFirstNonLoopBackHostInfo().getIpAddress();
+        String port = resolver.getProperty("spring.dynamic.thread-pool.local-server-port", "16691");
+        return combineParts(hostname, SEPARATOR, port);
+    }
+
+    /**
      * Get default instance id.
      *
      * @param resolver  resolver

--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -13,6 +13,12 @@
       "description": "dynamic thread-pool server netty port."
     },
     {
+      "name": "spring.dynamic.thread-pool.local-server-port",
+      "type": "java.lang.String",
+      "defaultValue": "19961",
+      "description": "dynamic thread-pool local server port."
+    },
+    {
       "name": "spring.dynamic.thread-pool.report-type",
       "type": "java.lang.String",
       "defaultValue": "http",


### PR DESCRIPTION
- 修改RPC模块的日志为debug级别。

- 将部分接口的调用接入到RPC模块。这包括ThreadPoolAdapterController，WebThreadPoolController,和WebThreadPoolRunStateController三个接口的所有方法，同时加入一个新的配置项，其含义为该服务对外暴露的netty服务器的端口，默认值为16691。
- server服务对其他线程池服务的连接为使用时创建所以在首次调用是会比较慢，后续会通过FactoryBean的形式加入需要代理的接口。