### PR TITLE
The client and server are connected synchronously

### DIFF
--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/client/NettyClientConnection.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/client/NettyClientConnection.java
@@ -108,7 +108,7 @@ public class NettyClientConnection implements ClientConnection {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         if (this.channel == null) {
             return;
         }

--- a/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/server/NettyServerConnection.java
+++ b/hippo4j-rpc/src/main/java/cn/hippo4j/rpc/server/NettyServerConnection.java
@@ -105,12 +105,13 @@ public class NettyServerConnection extends AbstractNettyHandlerManager implement
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         if (port == null) {
             return;
         }
-        leader.shutdownGracefully();
-        worker.shutdownGracefully();
+        this.leader.shutdownGracefully();
+        this.worker.shutdownGracefully();
+        this.channel.close();
         this.future.channel().close();
         log.info("The server is shut down and no more requests are received. The release port is {}", port.getPort());
     }
@@ -146,4 +147,5 @@ public class NettyServerConnection extends AbstractNettyHandlerManager implement
         super.addFirst(handler);
         return this;
     }
+
 }

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyServerSupportTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyServerSupportTest.java
@@ -35,6 +35,7 @@ public class NettyServerSupportTest {
         }
         Assert.assertTrue(support.isActive());
         support.close();
+        ThreadUtil.sleep(1000L);
         Assert.assertFalse(support.isActive());
     }
 

--- a/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyServerSupportTest.java
+++ b/hippo4j-rpc/src/test/java/cn/hippo4j/rpc/support/NettyServerSupportTest.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 public class NettyServerSupportTest {
 
     @Test
-    public void bind() throws IOException {
+    public synchronized void bind() throws IOException {
         NettyServerSupport support = new NettyServerSupport(() -> 8891, InstanceServerLoader.class);
         support.bind();
         while (!support.isActive()) {


### PR DESCRIPTION
rpc 模块的测试用例会出现随机的异常情况，经排查发现可能是由于其他测试用例的影响导致rpc模块的服务器端没有及时释放端口，导致后续的验证失败。
现在将其改为同步方式进行，避免其他线程的影响，同时延长断言前的等待时间