### PR TITLE
Add spring.application.name for hippo4j-spring-boot-starter-adapter-rabbitmq-example

### DIFF
--- a/hippo4j-example/hippo4j-spring-boot-starter-adapter-rabbitmq-example/src/main/resources/application.properties
+++ b/hippo4j-example/hippo4j-spring-boot-starter-adapter-rabbitmq-example/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 server.port=8091
 
 spring.profiles.active=dev
+spring.application.name=hippo4j-spring-boot-starter-adapter-rabbitmq-example
+
 spring.dynamic.thread-pool.server-addr=http://localhost:6691
 spring.dynamic.thread-pool.namespace=prescription
 spring.dynamic.thread-pool.item-id=dynamic-threadpool-example


### PR DESCRIPTION
Add spring.application.name for hippo4j-spring-boot-starter-adapter-rabbitmq-example

Fixes #1019
