### PR TITLE
refactor to BlockingQueueTypeEnum

### DIFF
--- a/hippo4j-common/src/main/java/cn/hippo4j/common/web/exception/NotSupportedException.java
+++ b/hippo4j-common/src/main/java/cn/hippo4j/common/web/exception/NotSupportedException.java
@@ -1,0 +1,12 @@
+package cn.hippo4j.common.web.exception;
+
+/**
+ * This exception is thrown when a context implementation does not support the operation being invoked.
+ */
+public class NotSupportedException extends AbstractException {
+
+    public NotSupportedException(String message, ErrorCode errorCode) {
+        super(message, null, errorCode);
+    }
+
+}


### PR DESCRIPTION
Fixes #1025

Changes proposed in this pull request:
- refactor to BlockingQueueTypeEnum.  Separate duties to specify enum item.  It's  a 
 classic example in 《effective java》.

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
