### PR TITLE
Refactor : generic type custom BlockingQueue support

### DIFF
--- a/hippo4j-common/src/main/java/cn/hippo4j/common/executor/support/CustomBlockingQueue.java
+++ b/hippo4j-common/src/main/java/cn/hippo4j/common/executor/support/CustomBlockingQueue.java
@@ -22,7 +22,7 @@ import java.util.concurrent.BlockingQueue;
 /**
  * Custom blocking-queue.
  */
-public interface CustomBlockingQueue {
+public interface CustomBlockingQueue<T> {
 
     /**
      * Gets the custom blocking queue type.
@@ -45,5 +45,5 @@ public interface CustomBlockingQueue {
      *
      * @return
      */
-    BlockingQueue generateBlockingQueue();
+    BlockingQueue<T> generateBlockingQueue();
 }

--- a/hippo4j-common/src/main/java/cn/hippo4j/common/spi/DynamicThreadPoolServiceLoader.java
+++ b/hippo4j-common/src/main/java/cn/hippo4j/common/spi/DynamicThreadPoolServiceLoader.java
@@ -17,6 +17,8 @@
 
 package cn.hippo4j.common.spi;
 
+import cn.hippo4j.common.spi.annotation.SingletonSPI;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,14 +28,20 @@ import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import cn.hippo4j.common.spi.annotation.SingletonSPI;
-
 /**
  * Dynamic thread-pool service loader.
  */
 public class DynamicThreadPoolServiceLoader {
 
-    private static final Map<Class<?>, Collection<Object>> SERVICES = new ConcurrentHashMap<>();
+    /**
+     * safe container。
+     * key : SPI interface class type.
+     * value : collection whose elements are object of key's class type.
+     */
+    private static final Map<Class<?>, Collection<?>> SERVICES = new ConcurrentHashMap<>();
+
+    private DynamicThreadPoolServiceLoader() {
+    }
 
     /**
      * Register.
@@ -53,8 +61,8 @@ public class DynamicThreadPoolServiceLoader {
      * @param <T>
      * @return
      */
-    private static <T> Collection<Object> load(final Class<T> serviceInterface) {
-        Collection<Object> result = new LinkedList<>();
+    private static <T> Collection<T> load(final Class<T> serviceInterface) {
+        Collection<T> result = new LinkedList<>();
         for (T each : ServiceLoader.load(serviceInterface)) {
             result.add(each);
         }
@@ -63,7 +71,7 @@ public class DynamicThreadPoolServiceLoader {
 
     /**
      * Get Service instances
-     * 
+     *
      * @param serviceClass serviceClass
      * @param <T>
      * @return

--- a/hippo4j-common/src/test/java/cn/hippo4j/common/spi/MyArrayBlockingQueue.java
+++ b/hippo4j-common/src/test/java/cn/hippo4j/common/spi/MyArrayBlockingQueue.java
@@ -1,0 +1,27 @@
+package cn.hippo4j.common.spi;
+
+import cn.hippo4j.common.executor.support.CustomBlockingQueue;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * SPI whit generic type test.
+ */
+public class MyArrayBlockingQueue implements CustomBlockingQueue<Runnable> {
+
+    @Override
+    public Integer getType() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return this.getClass().getSimpleName();
+    }
+
+    @Override
+    public BlockingQueue<Runnable> generateBlockingQueue() {
+        return new LinkedBlockingQueue<>(20);
+    }
+}

--- a/hippo4j-common/src/test/resources/META-INF/services/cn.hippo4j.common.executor.support.CustomBlockingQueue
+++ b/hippo4j-common/src/test/resources/META-INF/services/cn.hippo4j.common.executor.support.CustomBlockingQueue
@@ -1,0 +1,1 @@
+cn.hippo4j.common.spi.MyArrayBlockingQueue


### PR DESCRIPTION
Fixes #1035

Changes proposed in this pull request:
- 
CustomBlockingQueue is used to create custom BlockingQueue. BlockingQueue is a container in essence. So Add generic type to support parameterized type.
