### PR TITLE
Populate the default thread pool configuration to the thread pool instance (add attribute)

### DIFF
--- a/hippo4j-spring-boot/hippo4j-config-spring-boot-starter/src/main/java/cn/hippo4j/config/springboot/starter/support/DynamicThreadPoolPostProcessor.java
+++ b/hippo4j-spring-boot/hippo4j-config-spring-boot-starter/src/main/java/cn/hippo4j/config/springboot/starter/support/DynamicThreadPoolPostProcessor.java
@@ -214,6 +214,16 @@ public final class DynamicThreadPoolPostProcessor implements BeanPostProcessor {
                         .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getRejectedHandler).get()))
                 .threadNamePrefix(StringUtil.isBlank(executorProperties.getThreadNamePrefix()) ? executorProperties.getThreadPoolId() : executorProperties.getThreadNamePrefix())
                 .threadPoolId(executorProperties.getThreadPoolId())
+                .alarm(Optional.ofNullable(executorProperties.getAlarm())
+                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getAlarm).get()))
+                .activeAlarm(Optional.ofNullable(executorProperties.getActiveAlarm())
+                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getActiveAlarm).get()))
+                .capacityAlarm(Optional.ofNullable(executorProperties.getCapacityAlarm())
+                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getCapacityAlarm).get()))
+                .notify(Optional.ofNullable(executorProperties.getNotify())
+                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getNotify).get()))
+                .nodes(Optional.ofNullable(executorProperties.getNodes())
+                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getNodes).get()))
                 .build();
     }
 


### PR DESCRIPTION
Populate the default thread pool configuration to the thread pool instance (add attribute)
Fixes #1068 

Changes proposed in this pull request:
- 

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
