### PR TITLE
fix some properties default to null when buildExecutorProperties

### DIFF
--- a/hippo4j-spring-boot/hippo4j-config-spring-boot-starter/src/main/java/cn/hippo4j/config/springboot/starter/support/DynamicThreadPoolPostProcessor.java
+++ b/hippo4j-spring-boot/hippo4j-config-spring-boot-starter/src/main/java/cn/hippo4j/config/springboot/starter/support/DynamicThreadPoolPostProcessor.java
@@ -210,15 +210,15 @@ public final class DynamicThreadPoolPostProcessor implements BeanPostProcessor {
                 .threadNamePrefix(StringUtil.isBlank(executorProperties.getThreadNamePrefix()) ? executorProperties.getThreadPoolId() : executorProperties.getThreadNamePrefix())
                 .threadPoolId(executorProperties.getThreadPoolId())
                 .alarm(Optional.ofNullable(executorProperties.getAlarm())
-                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getAlarm).get()))
+                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getAlarm).orElse(null)))
                 .activeAlarm(Optional.ofNullable(executorProperties.getActiveAlarm())
-                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getActiveAlarm).get()))
+                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getActiveAlarm).orElse(null)))
                 .capacityAlarm(Optional.ofNullable(executorProperties.getCapacityAlarm())
-                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getCapacityAlarm).get()))
+                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getCapacityAlarm).orElse(null)))
                 .notify(Optional.ofNullable(executorProperties.getNotify())
-                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getNotify).get()))
+                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getNotify).orElse(null)))
                 .nodes(Optional.ofNullable(executorProperties.getNodes())
-                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getNodes).get()))
+                        .orElseGet(() -> Optional.ofNullable(configProperties.getDefaultExecutor()).map(ExecutorProperties::getNodes).orElse(null)))
                 .build();
     }
 


### PR DESCRIPTION
Fixes #1074

Changes proposed in this pull request:
- 

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)

Some properties default to null when cn.hippo4j.config.springboot.starter.support.DynamicThreadPoolPostProcessor#buildExecutorProperties.
