### PR TITLE
Replaced {} by %s

### DIFF
--- a/hippo4j-common/src/main/java/cn/hippo4j/common/design/builder/ThreadFactoryBuilder.java
+++ b/hippo4j-common/src/main/java/cn/hippo4j/common/design/builder/ThreadFactoryBuilder.java
@@ -55,10 +55,10 @@ public class ThreadFactoryBuilder implements Builder<ThreadFactory> {
 
     public ThreadFactoryBuilder priority(int priority) {
         if (priority < Thread.MIN_PRIORITY) {
-            throw new IllegalArgumentException(String.format("Thread priority ({}) must be >= {}", priority, Thread.MIN_PRIORITY));
+            throw new IllegalArgumentException(String.format("Thread priority (%s) must be >= %s", priority, Thread.MIN_PRIORITY));
         }
         if (priority > Thread.MAX_PRIORITY) {
-            throw new IllegalArgumentException(String.format("Thread priority ({}) must be <= {}", priority, Thread.MAX_PRIORITY));
+            throw new IllegalArgumentException(String.format("Thread priority (%s) must be <= %s", priority, Thread.MAX_PRIORITY));
         }
         this.priority = priority;
         return this;


### PR DESCRIPTION
Fixes #1095 

Changes proposed in this pull request:
- 

The use of {} in String.format in ThreadFactoryBuilder does not work, we need to change it to %s
