### PR TITLE
DynamicThreadPoolAdapterChoose can use lambda to simplify the code

### DIFF
--- a/hippo4j-common/src/main/java/cn/hippo4j/common/design/builder/ThreadFactoryBuilder.java
+++ b/hippo4j-common/src/main/java/cn/hippo4j/common/design/builder/ThreadFactoryBuilder.java
@@ -55,10 +55,10 @@ public class ThreadFactoryBuilder implements Builder<ThreadFactory> {
 
     public ThreadFactoryBuilder priority(int priority) {
         if (priority < Thread.MIN_PRIORITY) {
-            throw new IllegalArgumentException(String.format("Thread priority ({}) must be >= {}", priority, Thread.MIN_PRIORITY));
+            throw new IllegalArgumentException(String.format("Thread priority (%s) must be >= %s", priority, Thread.MIN_PRIORITY));
         }
         if (priority > Thread.MAX_PRIORITY) {
-            throw new IllegalArgumentException(String.format("Thread priority ({}) must be <= {}", priority, Thread.MAX_PRIORITY));
+            throw new IllegalArgumentException(String.format("Thread priority (%s) must be <= %s", priority, Thread.MAX_PRIORITY));
         }
         this.priority = priority;
         return this;

--- a/hippo4j-core/src/main/java/cn/hippo4j/core/executor/support/adpter/DynamicThreadPoolAdapterChoose.java
+++ b/hippo4j-core/src/main/java/cn/hippo4j/core/executor/support/adpter/DynamicThreadPoolAdapterChoose.java
@@ -76,9 +76,7 @@ public class DynamicThreadPoolAdapterChoose {
      */
     public static void replace(Object executor, Executor dynamicThreadPoolExecutor) {
         Optional<DynamicThreadPoolAdapter> dynamicThreadPoolAdapterOptional = DYNAMIC_THREAD_POOL_ADAPTERS.stream().filter(each -> each.match(executor)).findFirst();
-        if (dynamicThreadPoolAdapterOptional.isPresent()) {
-            dynamicThreadPoolAdapterOptional.get().replace(executor, dynamicThreadPoolExecutor);
-        }
+        dynamicThreadPoolAdapterOptional.ifPresent(dynamicThreadPoolAdapter -> dynamicThreadPoolAdapter.replace(executor, dynamicThreadPoolExecutor));
     }
 
     /**


### PR DESCRIPTION
Fixes #1094 

Changes proposed in this pull request:
- 

DynamicThreadPoolAdapterChoose can use lambda to simplify the code.
