### PR TITLE
IdentifyUtil 77 lines of StringBuilder use string replace

### DIFF
--- a/hippo4j-core/src/main/java/cn/hippo4j/core/toolkit/IdentifyUtil.java
+++ b/hippo4j-core/src/main/java/cn/hippo4j/core/toolkit/IdentifyUtil.java
@@ -74,13 +74,11 @@ public class IdentifyUtil {
             ip = inetUtil.findFirstNonLoopBackHostInfo().getIpAddress();
             port = environment.getProperty("server.port", "8080");
         }
-        String identify = new StringBuilder()
-                .append(ip)
-                .append(":")
-                .append(port)
-                .append(IDENTIFY_SLICER_SYMBOL)
-                .append(CLIENT_IDENTIFICATION_VALUE)
-                .toString();
+        String identify = ip
+                + ":"
+                + port
+                + IDENTIFY_SLICER_SYMBOL
+                + CLIENT_IDENTIFICATION_VALUE;
         IDENTIFY = identify;
         return identify;
     }


### PR DESCRIPTION
Fixes #1093

Changes proposed in this pull request:
- IdentifyUtil 77 lines of StringBuilder can use string + instead to simplify the code

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
