### PR TITLE
ThreadPoolMonitor use the new api 

### DIFF
--- a/hippo4j-spring-boot/hippo4j-config-spring-boot-starter/src/main/java/cn/hippo4j/config/springboot/starter/monitor/ThreadPoolMonitorExecutor.java
+++ b/hippo4j-spring-boot/hippo4j-config-spring-boot-starter/src/main/java/cn/hippo4j/config/springboot/starter/monitor/ThreadPoolMonitorExecutor.java
@@ -79,8 +79,8 @@ public class ThreadPoolMonitorExecutor implements ApplicationRunner, DisposableB
         // Execute dynamic thread pool monitoring component.
         collectScheduledExecutor.scheduleWithFixedDelay(
                 this::scheduleRunnable,
-                properties.getInitialDelay(),
-                properties.getCollectInterval(),
+                monitor.getInitialDelay(),
+                monitor.getCollectInterval(),
                 TimeUnit.MILLISECONDS);
         if (GlobalThreadPoolManage.getThreadPoolNum() > 0) {
             log.info("Dynamic thread pool: [{}]. The dynamic thread pool starts data collection and reporting.", getThreadPoolNum());


### PR DESCRIPTION
Fixes #1091 

Changes proposed in this pull request:
- the ThreadPoolMonitor use the new api instead of the deprecated api

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
