### PR TITLE
Could cn.hippo4j:hippo4j-config-zookeeper-spring-boot-starter-example:1.5.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/hippo4j-example/hippo4j-config-zookeeper-spring-boot-starter-example/pom.xml
+++ b/hippo4j-example/hippo4j-config-zookeeper-spring-boot-starter-example/pom.xml
@@ -28,18 +28,91 @@
             <groupId>cn.hippo4j</groupId>
             <artifactId>hippo4j-config-spring-boot-starter</artifactId>
             <version>${revision}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>error_prone_annotations</artifactId>
+                    <groupId>com.google.errorprone</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>checker-qual</artifactId>
+                    <groupId>org.checkerframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>commons-codec</artifactId>
+                    <groupId>commons-codec</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-boot-configuration-processor</artifactId>
+                    <groupId>org.springframework.boot</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hippo4j-spring-boot-starter-monitor-micrometer</artifactId>
+                    <groupId>cn.hippo4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hippo4j-spring-boot-starter-monitor-local-log</artifactId>
+                    <groupId>cn.hippo4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
             <version>5.1.0</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>audience-annotations</artifactId>
+                    <groupId>org.apache.yetus</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jsr305</artifactId>
+                    <groupId>com.google.code.findbugs</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>error_prone_annotations</artifactId>
+                    <groupId>com.google.errorprone</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>j2objc-annotations</artifactId>
+                    <groupId>com.google.j2objc</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>checker-qual</artifactId>
+                    <groupId>org.checkerframework</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                    <groupId>org.codehaus.mojo</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>failureaccess</artifactId>
+                    <groupId>com.google.guava</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>guava</artifactId>
+                    <groupId>com.google.guava</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>cn.hippo4j</groupId>
             <artifactId>hippo4j-example-core</artifactId>
             <version>${revision}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>transmittable-thread-local</artifactId>
+                    <groupId>com.alibaba</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+             
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>listenablefuture</artifactId>
+            <version>9999.0-empty-to-avoid-conflict-with-guava</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/126549527/231335398-26324072-6d15-490f-88f6-55eee32c7c98.png)
![image](https://user-images.githubusercontent.com/126549527/231335421-acf1398f-b431-49ad-a97a-b7ac2220d709.png)
![image](https://user-images.githubusercontent.com/126549527/231335522-8adddad1-874b-47f5-83a4-31b96e6a59f9.png)
![image](https://user-images.githubusercontent.com/126549527/231335558-d812a66a-5f79-4502-bf3c-e0de4e67d405.png)

Hi, I found that **_cn.hippo4j:hippo4j-config-zookeeper-spring-boot-starter-example:1.5.0-SNAPSHOT_**’s pom file introduced **_83_** dependencies. However,
 among them, **_13_** libraries (**_16%_** have not been used by your project), the redundant dependencies are listed below.

More seriously, **_1_** redundant dependencies contain security vulnerabilities (vulnerable libraries).

**_9_**  redundant libraries have not been maintained by developers for more than **_3_** years (outdated dependencies).

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies with security vulnerabilities and outdated. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code.

This PR **_cn.hippo4j:hippo4j-config-zookeeper-spring-boot-starter-example:1.5.0-SNAPSHOT_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant indirect dependencies:
        org.codehaus.mojo:animal-sniffer-annotations:1.17:compile [3 KB]
        org.apache.yetus:audience-annotations:0.5.0:compile [19 KB]
        com.google.errorprone:error_prone_annotations:2.2.0:compile [13 KB]
        cn.hippo4j:hippo4j-spring-boot-starter-monitor-micrometer:1.5.0-SNAPSHOT:compile [3 KB]
        cn.hippo4j:hippo4j-spring-boot-starter-monitor-local-log:1.5.0-SNAPSHOT:compile [4 KB]
        org.springframework.boot:spring-boot-configuration-processor:2.3.2.RELEASE:compile [113 KB]
        com.google.guava:failureaccess:1.0.1:compile [4 KB]
        com.google.guava:guava:27.0.1-jre:compile [2 MB]
        org.checkerframework:checker-qual:2.5.2:compile [188 KB]
        com.alibaba:transmittable-thread-local:2.12.1:compile [879 KB]
        com.google.j2objc:j2objc-annotations:1.1:compile [8 KB]
        com.google.code.findbugs:jsr305:3.0.2:compile [19 KB]
        commons-codec:commons-codec:1.14:compile [339 KB]

## Vulnerable libraries
com.google.guava:guava:27.0.1-jre (CVE-2020-8908)

## Outdated dependencies
org.apache.yetus:audience-annotations:0.5.0 (**_2099_** days without maintenance)
org.codehaus.mojo:animal-sniffer-annotations:1.17 (**_1755_** days without maintenance)
com.google.guava:guava:27.0.1-jre (**_1604_** days without maintenance)
com.google.j2objc:j2objc-annotations:1.1 (**_2274_** days without maintenance)
com.google.code.findbugs:jsr305:3.0.2 (**_2203_** days without maintenance)
commons-codec:commons-codec:1.14 (**_1198_** days without maintenance)
org.checkerframework:checker-qual:2.5.2 (**_1775_** days without maintenance)
com.google.guava:failureaccess:1.0.1 (**_1604_** days without maintenance)
com.google.errorprone:error_prone_annotations:2.2.0 (**_1919_** days without maintenance)
