### PR TITLE
Could cn.hippo4j:hippo4j-config-spring-boot-starter:1.5.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/hippo4j-spring-boot/hippo4j-config-spring-boot-starter/pom.xml
+++ b/hippo4j-spring-boot/hippo4j-config-spring-boot-starter/pom.xml
@@ -13,6 +13,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                   <artifactId>jakarta.annotation-api</artifactId>
+                   <groupId>jakarta.annotation</groupId>
+                </exclusion>
+             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -23,6 +29,20 @@
             <groupId>cn.hippo4j</groupId>
             <artifactId>hippo4j-core</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>spring-boot-configuration-processor</artifactId>
+                    <groupId>org.springframework.boot</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>error_prone_annotations</artifactId>
+                    <groupId>com.google.errorprone</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>checker-qual</artifactId>
+                    <groupId>org.checkerframework</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>cn.hippo4j</groupId>
@@ -40,6 +60,12 @@
             <artifactId>spring-cloud-starter-alibaba-nacos-config</artifactId>
             <version>${spring-cloud-starter-alibaba-nacos-config.version}</version>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <artifactId>spring-security-crypto</artifactId>
+                    <groupId>org.springframework.security</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.ctrip.framework.apollo</groupId>
@@ -53,12 +79,28 @@
             <version>${consul.version}</version>
             <scope>compile</scope>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                    <groupId>org.bouncycastle</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>spring-security-rsa</artifactId>
+                    <groupId>org.springframework.security</groupId>
+                </exclusion>
+            </exclusions>            
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
             <version>${curator-framework.version}</version>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <artifactId>audience-annotations</artifactId>
+                    <groupId>org.apache.yetus</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.etcd</groupId>
@@ -104,12 +146,23 @@
                     <groupId>io.grpc</groupId>
                     <artifactId>grpc-all</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>circuitbreaker-common</artifactId>
+                    <groupId>com.tencent.polaris</groupId>
+                 </exclusion>
+                 <exclusion>
+                    <artifactId>polaris-circuitbreaker-api</artifactId>
+                    <groupId>com.tencent.polaris</groupId>
+                 </exclusion>
+                 <exclusion>
+                    <artifactId>simpleclient_common</artifactId>
+                    <groupId>io.prometheus</groupId>
+                 </exclusion>
+                 <exclusion>
+                    <artifactId>simpleclient_httpserver</artifactId>
+                    <groupId>io.prometheus</groupId>
+                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>cn.hippo4j</groupId>
@@ -130,6 +183,12 @@
             <groupId>cn.hippo4j</groupId>
             <artifactId>hippo4j-spring-boot-starter-monitor-micrometer</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.64</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/126549527/231358898-095a2869-e23b-4ab7-b0c7-f245eb7ae4c1.png)
![image](https://user-images.githubusercontent.com/126549527/231358937-b0decc2b-08c8-475b-a925-ffc1e8eb763c.png)
![image](https://user-images.githubusercontent.com/126549527/231358983-ff451be0-a478-4065-84a6-d9869efb8852.png)
![image](https://user-images.githubusercontent.com/126549527/231359087-6ca7d873-7330-4377-8d41-b50fbf4efd33.png)
![image](https://user-images.githubusercontent.com/126549527/231359115-e3fa76f7-98f6-4fcf-9963-636ca747ddc8.png)
![image](https://user-images.githubusercontent.com/126549527/231359138-2f20bdb2-8bf7-45d1-bab1-b5dad5ad0c21.png)
![image](https://user-images.githubusercontent.com/126549527/231359186-9c0fdf17-314b-44e8-9789-17dbfb96fd09.png)
![image](https://user-images.githubusercontent.com/126549527/231359201-ad2bcb26-e724-45ab-b7cb-7a874a1c92b7.png)
![image](https://user-images.githubusercontent.com/126549527/231359219-31641b0e-2879-4a74-aa27-727ec132132e.png)
![image](https://user-images.githubusercontent.com/126549527/231359241-e899fd54-e98d-423d-95be-426147332ac5.png)
![image](https://user-images.githubusercontent.com/126549527/231359288-48c21684-2d44-4595-87ba-f5abcb790ba5.png)

Hi, I found that **_cn.hippo4j:hippo4j-config-spring-boot-starter:1.5.0-SNAPSHOT_**’s pom file introduced **_182_** dependencies. However, among them, **_12_** libraries (**_7%_** have not been used by your project), the redundant dependencies are listed below.

More seriously, **_4_**  redundant libraries have not been maintained by developers for more than **_3_** years (outdated dependencies).

**_1_** redundant library has introduced an open source license conflict **_jakarta.annotation:jakarta.annotation-api:1.3.5_**. The dependent open source license is **_EPL 2.0_**(**_EPL 2.0_** cannot be used by the project with license **_The Apache Software License, Version 2.0_**).

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies with outdated and open source license conflict. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code.

This PR **_cn.hippo4j:hippo4j-config-spring-boot-starter:1.5.0-SNAPSHOT_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant direct dependencies:
        org.springframework.boot:spring-boot-configuration-processor:2.3.2.RELEASE:compile [113 KB]
#### Redundant indirect dependencies:
        io.prometheus:simpleclient_common:0.11.0:compile [7 KB]
        com.tencent.polaris:polaris-circuitbreaker-api:1.7.2:compile [2 KB]
        org.apache.yetus:audience-annotations:0.5.0:compile [19 KB]
        org.springframework.security:spring-security-crypto:5.3.3.RELEASE:compile [78 KB]
        com.tencent.polaris:circuitbreaker-common:1.7.2:compile [32 KB]
        jakarta.annotation:jakarta.annotation-api:1.3.5:compile [24 KB]
        org.bouncycastle:bcpkix-jdk15on:1.64:compile [857 KB]
        org.springframework.security:spring-security-rsa:1.0.9.RELEASE:compile [19 KB]
        io.prometheus:simpleclient_httpserver:0.11.0:compile [10 KB]
        com.google.errorprone:error_prone_annotations:2.4.0:compile [13 KB]
        org.checkerframework:checker-qual:3.4.1:compile [207 KB]

## Outdated dependencies
org.bouncycastle:bcpkix-jdk15on:1.64 (**_1278_** days without maintenance)
org.apache.yetus:audience-annotations:0.5.0 (**_2099_** days without maintenance)
jakarta.annotation:jakarta.annotation-api:1.3.5 (**_1349_** days without maintenance)
org.springframework.security:spring-security-rsa:1.0.9.RELEASE (**_1220_** days without maintenance)

## Open source license conflict dependencies
jakarta.annotation:jakarta.annotation-api:1.3.5