### PR TITLE
fix notify config page size null

### DIFF
--- a/hippo4j-ui/src/views/hippo4j/notify/index.vue
+++ b/hippo4j-ui/src/views/hippo4j/notify/index.vue
@@ -400,6 +400,7 @@ export default {
         alarmType: false,
       },
       visible: true,
+      size: 500,
     };
   },
   created() {


### PR DESCRIPTION
Fixes #1156

Changes proposed in this pull request:
- fix notify config page size null
- default size 500

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
