### PR TITLE
Fix BootstrapConfigProperties default values using Collections.emptyList causing Exception

### DIFF
--- a/hippo4j-spring-boot/hippo4j-config-spring-boot-starter/src/main/java/cn/hippo4j/config/springboot/starter/config/BootstrapConfigProperties.java
+++ b/hippo4j-spring-boot/hippo4j-config-spring-boot-starter/src/main/java/cn/hippo4j/config/springboot/starter/config/BootstrapConfigProperties.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -86,7 +87,7 @@ public class BootstrapConfigProperties implements BootstrapPropertiesInterface {
     /**
      * Notify platforms.
      */
-    private List<NotifyPlatformProperties> notifyPlatforms = Collections.emptyList();
+    private List<NotifyPlatformProperties> notifyPlatforms = new ArrayList<>();
 
     /**
      * Check thread pool running status interval.


### PR DESCRIPTION
Fixes #1131 

Changes proposed in this pull request:
- Fix the problem that if you use the Collections.emptyList method, the Collections.emptyList.add method is triggered during the binding of the springboot parameter, and the UnsupportedOperationException is triggered, resulting in the failure to start.
