### PR TITLE
fix H2 database usage error

### DIFF
--- a/threadpool/server/auth/src/main/java/cn/hippo4j/auth/model/UserInfo.java
+++ b/threadpool/server/auth/src/main/java/cn/hippo4j/auth/model/UserInfo.java
@@ -31,7 +31,7 @@ import java.util.Date;
  * User info.
  */
 @Data
-@TableName("user")
+@TableName("`user`")
 public class UserInfo {
 
     /**


### PR DESCRIPTION
Fixes #1274

Changes proposed in this pull request:
-  Modify annotation to`@Table(`ˋ`user`ˋ`)`So that `user` is not recognized as a keyword

> Fix H2 database usage error.
#1274 
