### PR TITLE
fix : use rpc to complete the call

### DIFF
--- a/infra/common/src/main/java/cn/hippo4j/common/model/InstanceInfo.java
+++ b/infra/common/src/main/java/cn/hippo4j/common/model/InstanceInfo.java
@@ -48,11 +48,15 @@ public class InstanceInfo {
 
     private String clientBasePath;
 
+    private Boolean enableRpc;
+
     private String callBackUrl;
 
     private String identify;
 
     private String active;
+
+    private String clientVersion;
 
     private volatile String vipAddress;
 

--- a/infra/common/src/main/java/cn/hippo4j/common/model/ThreadDetailStateInfo.java
+++ b/infra/common/src/main/java/cn/hippo4j/common/model/ThreadDetailStateInfo.java
@@ -23,6 +23,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -33,7 +34,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Accessors(chain = true)
-public class ThreadDetailStateInfo {
+public class ThreadDetailStateInfo implements Serializable {
 
     /**
      * threadId

--- a/infra/common/src/main/java/cn/hippo4j/common/model/ThreadPoolBaseInfo.java
+++ b/infra/common/src/main/java/cn/hippo4j/common/model/ThreadPoolBaseInfo.java
@@ -20,12 +20,14 @@ package cn.hippo4j.common.model;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
+import java.io.Serializable;
+
 /**
  * Thread-pool base info.
  */
 @Data
 @Accessors(chain = true)
-public class ThreadPoolBaseInfo {
+public class ThreadPoolBaseInfo implements Serializable {
 
     /**
      * coreSize

--- a/starters/threadpool/server/pom.xml
+++ b/starters/threadpool/server/pom.xml
@@ -34,6 +34,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>cn.hippo4j</groupId>
+            <artifactId>hippo4j-threadpool-rpc</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>

--- a/starters/threadpool/server/src/main/java/cn/hippo4j/springboot/starter/config/BootstrapProperties.java
+++ b/starters/threadpool/server/src/main/java/cn/hippo4j/springboot/starter/config/BootstrapProperties.java
@@ -54,6 +54,11 @@ public class BootstrapProperties implements BootstrapPropertiesInterface {
     private String nettyServerPort;
 
     /**
+     * is the rpc switch turned on
+     */
+    private Boolean enableRpc = false;
+
+    /**
      * Report type
      */
     private String reportType;

--- a/starters/threadpool/server/src/main/java/cn/hippo4j/springboot/starter/config/DynamicThreadPoolAutoConfiguration.java
+++ b/starters/threadpool/server/src/main/java/cn/hippo4j/springboot/starter/config/DynamicThreadPoolAutoConfiguration.java
@@ -92,7 +92,8 @@ import org.springframework.core.env.ConfigurableEnvironment;
 @ConditionalOnBean(MarkerConfiguration.Marker.class)
 @EnableConfigurationProperties(BootstrapProperties.class)
 @ConditionalOnProperty(prefix = Constants.CONFIGURATION_PROPERTIES_PREFIX, value = "enable", matchIfMissing = true, havingValue = "true")
-@ImportAutoConfiguration({WebAdapterConfiguration.class, NettyClientConfiguration.class, DiscoveryConfiguration.class, MessageConfiguration.class, UtilAutoConfiguration.class})
+@ImportAutoConfiguration({WebAdapterConfiguration.class, DiscoveryConfiguration.class, MessageConfiguration.class, UtilAutoConfiguration.class,
+        NettyServerConfiguration.class})
 public class DynamicThreadPoolAutoConfiguration {
 
     private final BootstrapProperties properties;

--- a/starters/threadpool/server/src/main/java/cn/hippo4j/springboot/starter/config/NettyServerConfiguration.java
+++ b/starters/threadpool/server/src/main/java/cn/hippo4j/springboot/starter/config/NettyServerConfiguration.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.hippo4j.springboot.starter.config;
+
+import cn.hippo4j.adapter.base.ThreadPoolAdapterParameter;
+import cn.hippo4j.adapter.base.ThreadPoolAdapterState;
+import cn.hippo4j.common.model.*;
+import cn.hippo4j.rpc.discovery.ServerPort;
+import cn.hippo4j.rpc.handler.ServerBareTakeHandler;
+import cn.hippo4j.rpc.handler.ServerTakeHandler;
+import cn.hippo4j.rpc.connection.SimpleServerConnection;
+import cn.hippo4j.rpc.server.Server;
+import cn.hippo4j.rpc.server.ServerSupport;
+import cn.hippo4j.springboot.starter.controller.ThreadPoolAdapterController;
+import cn.hippo4j.springboot.starter.controller.WebThreadPoolController;
+import cn.hippo4j.springboot.starter.controller.WebThreadPoolRunStateController;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class NettyServerConfiguration {
+
+    ServerPort serverPort;
+
+    final BootstrapProperties properties;
+    final ThreadPoolAdapterController threadPoolAdapterController;
+    final WebThreadPoolController webThreadPoolController;
+    final WebThreadPoolRunStateController webThreadPoolRunStateController;
+
+    private static final String GET_POOL_BASE_STATE = "getPoolBaseState";
+    private static final String GET_POOL_RUN_STATE = "getPoolRunState";
+    private static final String UPDATE_WEB_THREAD_POOL = "updateWebThreadPool";
+    private static final String GET_ADAPTER_THREAD_POOL = "getAdapterThreadPool";
+    private static final String UPDATE_ADAPTER_THREAD_POOL = "updateAdapterThreadPool";
+    private static final String GET_WEB_POOL_RUN_STATE = "getWebPoolRunState";
+    private static final String GET_THREAD_STATE_DETAIL = "getThreadStateDetail";
+
+    @PostConstruct
+    public void nettyServerPort() throws IOException {
+        if (Boolean.FALSE.equals(properties.getEnableRpc())) {
+            return;
+        }
+        this.serverPort = new ServerRandomPort();
+        // getPoolBaseState
+        ServerTakeHandler<String, Result<ThreadPoolBaseInfo>> getPoolBaseState =
+                new ServerTakeHandler<>(GET_POOL_BASE_STATE, webThreadPoolController::getPoolBaseState);
+        // getPoolRunState
+        ServerBareTakeHandler<Result<ThreadPoolRunStateInfo>> getPoolRunState =
+                new ServerBareTakeHandler<>(GET_POOL_RUN_STATE, webThreadPoolController::getPoolRunState);
+        // updateWebThreadPool
+        ServerTakeHandler<ThreadPoolParameterInfo, Result<Void>> updateWebThreadPool =
+                new ServerTakeHandler<>(UPDATE_WEB_THREAD_POOL, webThreadPoolController::updateWebThreadPool);
+        // getAdapterThreadPool
+        ServerTakeHandler<ThreadPoolAdapterParameter, Result<ThreadPoolAdapterState>> getAdapterThreadPool =
+                new ServerTakeHandler<>(GET_ADAPTER_THREAD_POOL, threadPoolAdapterController::getAdapterThreadPool);
+        // updateAdapterThreadPool
+        ServerTakeHandler<ThreadPoolAdapterParameter, Result<Void>> updateAdapterThreadPool =
+                new ServerTakeHandler<>(UPDATE_ADAPTER_THREAD_POOL, threadPoolAdapterController::updateAdapterThreadPool);
+        // getWebPoolRunState
+        ServerTakeHandler<String, Result<ThreadPoolRunStateInfo>> getWebPoolRunState =
+                new ServerTakeHandler<>(GET_WEB_POOL_RUN_STATE, webThreadPoolRunStateController::getPoolRunState);
+        // getThreadStateDetail
+        ServerTakeHandler<String, Result<List<ThreadDetailStateInfo>>> getThreadStateDetail =
+                new ServerTakeHandler<>(GET_THREAD_STATE_DETAIL, webThreadPoolRunStateController::getThreadStateDetail);
+
+        try (
+                SimpleServerConnection connection = new SimpleServerConnection(
+                        getPoolBaseState,
+                        getPoolRunState,
+                        updateWebThreadPool,
+                        getAdapterThreadPool,
+                        updateAdapterThreadPool,
+                        getWebPoolRunState,
+                        getThreadStateDetail);
+                Server server = new ServerSupport(serverPort, connection)) {
+            if (log.isInfoEnabled()) {
+                log.info("Netty server started, binding to port {}", serverPort.getPort());
+            }
+            server.bind();
+        }
+    }
+
+    public int getServerPort() {
+        return serverPort == null ? 0 : serverPort.getPort();
+    }
+
+    /**
+     * Safely create random ports
+     */
+    static class ServerRandomPort implements ServerPort {
+
+        final int port = getRandomPort();
+
+        @Override
+        public int getPort() {
+            return port;
+        }
+
+        private int getRandomPort() {
+            try (ServerSocket socket = new ServerSocket(0)) {
+                return socket.getLocalPort();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+}

--- a/starters/threadpool/server/src/main/java/cn/hippo4j/springboot/starter/core/ClientWorker.java
+++ b/starters/threadpool/server/src/main/java/cn/hippo4j/springboot/starter/core/ClientWorker.java
@@ -205,7 +205,9 @@ public class ClientWorker implements DisposableBean {
         if (isInitializingCacheList) {
             headers.put(LONG_PULLING_TIMEOUT_NO_HANGUP, "true");
         }
-        headers.put(CLIENT_VERSION, version);
+        if (version != null) {
+            headers.put(CLIENT_VERSION, version);
+        }
         try {
             long readTimeoutMs = timeout + Math.round(timeout >> 1);
             Result result = agent.httpPostByConfig(LISTENER_PATH, headers, params, readTimeoutMs);

--- a/starters/threadpool/server/src/main/java/cn/hippo4j/springboot/starter/toolkit/CloudCommonIdUtil.java
+++ b/starters/threadpool/server/src/main/java/cn/hippo4j/springboot/starter/toolkit/CloudCommonIdUtil.java
@@ -45,6 +45,19 @@ public class CloudCommonIdUtil {
     }
 
     /**
+     * Get netty server ip port.
+     *
+     * @param serverPort serverPort
+     * @param inetUtils  inet utils
+     * @return ip and port
+     */
+    public static String getNettyServerIpPort(int serverPort, InetUtils inetUtils) {
+        String hostname = inetUtils.findFirstNonLoopBackHostInfo().getIpAddress();
+        String port = String.valueOf(serverPort);
+        return combineParts(hostname, SEPARATOR, port);
+    }
+
+    /**
      * Get default instance id.
      *
      * @param resolver  resolver

--- a/starters/threadpool/server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/starters/threadpool/server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -13,6 +13,12 @@
       "description": "dynamic thread-pool server netty port."
     },
     {
+      "name": "spring.dynamic.thread-pool.enable-rpc",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "dynamic thread-pool rpc switch."
+    },
+    {
       "name": "spring.dynamic.thread-pool.report-type",
       "type": "java.lang.String",
       "defaultValue": "http",

--- a/threadpool/adapter/base/src/main/java/cn/hippo4j/adapter/base/ThreadPoolAdapterCacheConfig.java
+++ b/threadpool/adapter/base/src/main/java/cn/hippo4j/adapter/base/ThreadPoolAdapterCacheConfig.java
@@ -53,6 +53,16 @@ public class ThreadPoolAdapterCacheConfig {
     private String clientAddress;
 
     /**
+     * Open server address
+     */
+    private String nettyServerAddress;
+
+    /**
+     * rpc switch
+     */
+    private Boolean enableRpc = false;
+
+    /**
      * Thread-pool adapter states
      */
     private List<ThreadPoolAdapterState> threadPoolAdapterStates;

--- a/threadpool/adapter/base/src/main/java/cn/hippo4j/adapter/base/ThreadPoolAdapterState.java
+++ b/threadpool/adapter/base/src/main/java/cn/hippo4j/adapter/base/ThreadPoolAdapterState.java
@@ -46,6 +46,16 @@ public class ThreadPoolAdapterState {
     private String clientAddress;
 
     /**
+     * Open server address
+     */
+    private String nettyServerAddress;
+
+    /**
+     * rpc switch
+     */
+    private Boolean enableRpc = false;
+
+    /**
      * Core size
      */
     private Integer coreSize;

--- a/threadpool/server/config/pom.xml
+++ b/threadpool/server/config/pom.xml
@@ -20,6 +20,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>cn.hippo4j</groupId>
+            <artifactId>hippo4j-threadpool-rpc</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/threadpool/server/config/src/main/java/cn/hippo4j/config/service/ThreadPoolAdapterService.java
+++ b/threadpool/server/config/src/main/java/cn/hippo4j/config/service/ThreadPoolAdapterService.java
@@ -18,18 +18,27 @@
 package cn.hippo4j.config.service;
 
 import cn.hippo4j.adapter.base.ThreadPoolAdapterCacheConfig;
+import cn.hippo4j.adapter.base.ThreadPoolAdapterParameter;
 import cn.hippo4j.adapter.base.ThreadPoolAdapterState;
+import cn.hippo4j.common.constant.ConfigModifyTypeConstants;
 import cn.hippo4j.common.extension.design.AbstractSubjectCenter;
 import cn.hippo4j.common.extension.design.Observer;
 import cn.hippo4j.common.extension.design.ObserverMessage;
 import cn.hippo4j.common.toolkit.CollectionUtil;
 import cn.hippo4j.common.toolkit.JSONUtil;
+import cn.hippo4j.common.toolkit.UserContext;
+import cn.hippo4j.common.toolkit.BeanUtil;
 import cn.hippo4j.common.toolkit.StringUtil;
 import cn.hippo4j.common.toolkit.http.HttpUtil;
 import cn.hippo4j.common.model.Result;
 import cn.hippo4j.config.model.biz.adapter.ThreadPoolAdapterReqDTO;
 import cn.hippo4j.config.model.biz.adapter.ThreadPoolAdapterRespDTO;
+import cn.hippo4j.config.model.biz.threadpool.ConfigModifySaveReqDTO;
+import cn.hippo4j.config.verify.ConfigModificationVerifyServiceChoose;
+import cn.hippo4j.rpc.support.AddressUtil;
+import cn.hippo4j.rpc.client.ClientSupport;
 import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -51,12 +60,15 @@ import static cn.hippo4j.common.constant.Constants.IDENTIFY_SLICER_SYMBOL;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class ThreadPoolAdapterService {
 
     /**
      * Map&lt;mark, Map&lt;tenantItem, Map&lt;threadPoolKey, List&lt;ThreadPoolAdapterState&gt;&gt;&gt;&gt;
      */
     private static final Map<String, Map<String, Map<String, List<ThreadPoolAdapterState>>>> THREAD_POOL_ADAPTER_MAP = new ConcurrentHashMap<>();
+
+    private final ConfigModificationVerifyServiceChoose configModificationVerifyServiceChoose;
 
     static {
         AbstractSubjectCenter.register(AbstractSubjectCenter.SubjectType.CLEAR_CONFIG_CACHE, new ClearThreadPoolAdapterCache());
@@ -83,11 +95,15 @@ public class ThreadPoolAdapterService {
                         adapterStateList = new ArrayList<>();
                         tenantItemMap.put(adapterState.getThreadPoolKey(), adapterStateList);
                     }
-                    Optional<ThreadPoolAdapterState> first = adapterStateList.stream().filter(state -> Objects.equals(state.getClientAddress(), each.getClientAddress())).findFirst();
+                    String clientAddress = each.getClientAddress();
+                    String nettyServerAddress = each.getNettyServerAddress();
+                    Optional<ThreadPoolAdapterState> first = adapterStateList.stream().filter(state -> Objects.equals(state.getClientAddress(), clientAddress)).findFirst();
                     if (!first.isPresent()) {
                         ThreadPoolAdapterState state = new ThreadPoolAdapterState();
-                        state.setClientAddress(each.getClientAddress());
+                        state.setClientAddress(clientAddress);
                         state.setIdentify(each.getClientIdentify());
+                        state.setNettyServerAddress(nettyServerAddress);
+                        state.setEnableRpc(each.getEnableRpc());
                         adapterStateList.add(state);
                     }
                 }
@@ -100,25 +116,34 @@ public class ThreadPoolAdapterService {
                 .map(each -> each.get(requestParameter.getTenant() + IDENTIFY_SLICER_SYMBOL + requestParameter.getItem()))
                 .map(each -> each.get(requestParameter.getThreadPoolKey()))
                 .orElse(new ArrayList<>());
-        List<String> addressList = actual.stream().map(ThreadPoolAdapterState::getClientAddress).collect(Collectors.toList());
-        List<ThreadPoolAdapterRespDTO> result = new ArrayList<>(addressList.size());
-        addressList.forEach(each -> {
-            String url = StringUtil.newBuilder("http://", each, "/adapter/thread-pool/info");
-            Map<String, String> param = new HashMap<>();
-            param.put("mark", requestParameter.getMark());
-            param.put("threadPoolKey", requestParameter.getThreadPoolKey());
-            try {
-                String resultStr = HttpUtil.get(url, param);
-                if (StringUtil.isNotBlank(resultStr)) {
-                    Result<ThreadPoolAdapterRespDTO> restResult = JSONUtil.parseObject(resultStr, new TypeReference<Result<ThreadPoolAdapterRespDTO>>() {
-                    });
-                    result.add(restResult.getData());
-                }
-            } catch (Throwable ex) {
-                log.error("Failed to get third-party thread pool data.", ex);
-            }
-        });
-        return result;
+        return actual.stream()
+                .map(t -> {
+                    try {
+                        if (Boolean.TRUE.equals(t.getEnableRpc())) {
+                            ThreadPoolAdapterParameter parameter = new ThreadPoolAdapterParameter();
+                            parameter.setThreadPoolKey(requestParameter.getThreadPoolKey());
+                            parameter.setMark(requestParameter.getMark());
+                            String nettyServerAddress = t.getNettyServerAddress();
+                            Result<ThreadPoolAdapterState> result = ClientSupport.clientSend(
+                                    nettyServerAddress, "getAdapterThreadPool", parameter);
+                            return BeanUtil.convert(result.getData(), ThreadPoolAdapterRespDTO.class);
+                        }
+                        String clientAddress = t.getClientAddress();
+                        String url = StringUtil.newBuilder("http://", clientAddress, "/adapter/thread-pool/info");
+                        Map<String, String> param = new HashMap<>();
+                        param.put("mark", requestParameter.getMark());
+                        param.put("threadPoolKey", requestParameter.getThreadPoolKey());
+                        String resultStr = HttpUtil.get(url, param);
+                        if (StringUtil.isNotBlank(resultStr)) {
+                            Result<ThreadPoolAdapterRespDTO> restResult = JSONUtil.parseObject(resultStr, new TypeReference<Result<ThreadPoolAdapterRespDTO>>() {
+                            });
+                            return restResult.getData();
+                        }
+                    } catch (Throwable ex) {
+                        log.error("Failed to get third-party thread pool data.", ex);
+                    }
+                    return null;
+                }).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
     public Set<String> queryThreadPoolKey(ThreadPoolAdapterReqDTO requestParameter) {
@@ -133,10 +158,52 @@ public class ThreadPoolAdapterService {
         return new HashSet<>();
     }
 
+    /**
+     * If the user's authority is the administrator authority, modify it directly, if not, add it to the database and wait for review
+     *
+     * @param requestParameter ThreadPoolAdapterReqDTO
+     */
+    public void updateThreadPool(ThreadPoolAdapterReqDTO requestParameter) {
+        if (UserContext.getUserRole().equals("ROLE_ADMIN")) {
+            List<ThreadPoolAdapterState> actual = Optional.ofNullable(THREAD_POOL_ADAPTER_MAP.get(requestParameter.getMark()))
+                    .map(each -> each.get(requestParameter.getTenant() + IDENTIFY_SLICER_SYMBOL + requestParameter.getItem()))
+                    .map(each -> each.get(requestParameter.getThreadPoolKey()))
+                    .orElse(new ArrayList<>());
+            actual.forEach(t -> {
+                if (Boolean.TRUE.equals(t.getEnableRpc())) {
+                    String nettyServerAddress = t.getNettyServerAddress();
+                    ThreadPoolAdapterParameter parameter = BeanUtil.convert(requestParameter, ThreadPoolAdapterParameter.class);
+                    ClientSupport.clientSend(nettyServerAddress, "updateAdapterThreadPool", parameter);
+                } else {
+                    for (String each : requestParameter.getClientAddressList()) {
+                        String urlString = StringUtil.newBuilder("http://", each, "/adapter/thread-pool/update");
+                        HttpUtil.post(urlString, requestParameter);
+                    }
+                }
+            });
+        } else {
+            ConfigModifySaveReqDTO modifySaveReqDTO = BeanUtil.convert(requestParameter, ConfigModifySaveReqDTO.class);
+            modifySaveReqDTO.setModifyUser(UserContext.getUserName());
+            modifySaveReqDTO.setTenantId(requestParameter.getTenant());
+            modifySaveReqDTO.setItemId(requestParameter.getItem());
+            modifySaveReqDTO.setTpId(requestParameter.getThreadPoolKey());
+            modifySaveReqDTO.setType(ConfigModifyTypeConstants.ADAPTER_THREAD_POOL);
+            configModificationVerifyServiceChoose.choose(modifySaveReqDTO.getType()).saveConfigModifyApplication(modifySaveReqDTO);
+        }
+    }
+
     public static void remove(String identify) {
         synchronized (ThreadPoolAdapterService.class) {
-            THREAD_POOL_ADAPTER_MAP.values()
-                    .forEach(each -> each.forEach((key, val) -> val.forEach((threadPoolKey, states) -> states.removeIf(adapterState -> Objects.equals(adapterState.getIdentify(), identify)))));
+            THREAD_POOL_ADAPTER_MAP.values().forEach(each -> each.forEach((key, val) -> val.forEach((threadPoolKey, states) -> {
+                states.stream()
+                        .filter(s -> Objects.equals(s.getIdentify(), identify))
+                        .forEach(t -> {
+                            if (Boolean.TRUE.equals(t.getEnableRpc())) {
+                                ClientSupport.closeClient(AddressUtil.getInetAddress(t.getNettyServerAddress()));
+                            }
+                        });
+                states.removeIf(s -> Objects.equals(s.getIdentify(), identify));
+            })));
         }
     }
 

--- a/threadpool/server/config/src/main/java/cn/hippo4j/config/service/biz/impl/AdapterThreadPoolConfigModificationVerifyServiceImpl.java
+++ b/threadpool/server/config/src/main/java/cn/hippo4j/config/service/biz/impl/AdapterThreadPoolConfigModificationVerifyServiceImpl.java
@@ -18,9 +18,6 @@
 package cn.hippo4j.config.service.biz.impl;
 
 import cn.hippo4j.common.constant.ConfigModifyTypeConstants;
-import cn.hippo4j.common.toolkit.StringUtil;
-import cn.hippo4j.common.toolkit.http.HttpUtil;
-import cn.hippo4j.config.model.biz.threadpool.ConfigModifyVerifyReqDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -36,11 +33,4 @@ public class AdapterThreadPoolConfigModificationVerifyServiceImpl extends Abstra
         return ConfigModifyTypeConstants.ADAPTER_THREAD_POOL;
     }
 
-    @Override
-    protected void updateThreadPoolParameter(ConfigModifyVerifyReqDTO reqDTO) {
-        for (String each : getClientAddress(reqDTO)) {
-            String urlString = StringUtil.newBuilder("http://", each, "/adapter/thread-pool/update");
-            HttpUtil.post(urlString, reqDTO);
-        }
-    }
 }

--- a/threadpool/server/config/src/main/java/cn/hippo4j/config/service/biz/impl/WebThreadPoolConfigModificationVerifyServiceImpl.java
+++ b/threadpool/server/config/src/main/java/cn/hippo4j/config/service/biz/impl/WebThreadPoolConfigModificationVerifyServiceImpl.java
@@ -18,9 +18,6 @@
 package cn.hippo4j.config.service.biz.impl;
 
 import cn.hippo4j.common.constant.ConfigModifyTypeConstants;
-import cn.hippo4j.common.toolkit.StringUtil;
-import cn.hippo4j.common.toolkit.http.HttpUtil;
-import cn.hippo4j.config.model.biz.threadpool.ConfigModifyVerifyReqDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -36,11 +33,4 @@ public class WebThreadPoolConfigModificationVerifyServiceImpl extends AbstractCo
         return ConfigModifyTypeConstants.WEB_THREAD_POOL;
     }
 
-    @Override
-    protected void updateThreadPoolParameter(ConfigModifyVerifyReqDTO reqDTO) {
-        for (String each : getClientAddress(reqDTO)) {
-            String urlString = StringUtil.newBuilder("http://", each, "/web/update/pool");
-            HttpUtil.post(urlString, reqDTO);
-        }
-    }
 }

--- a/threadpool/server/console/src/main/java/cn/hippo4j/console/controller/ThreadPoolAdapterController.java
+++ b/threadpool/server/console/src/main/java/cn/hippo4j/console/controller/ThreadPoolAdapterController.java
@@ -17,18 +17,11 @@
 
 package cn.hippo4j.console.controller;
 
-import cn.hippo4j.common.constant.ConfigModifyTypeConstants;
-import cn.hippo4j.common.toolkit.BeanUtil;
-import cn.hippo4j.common.toolkit.StringUtil;
-import cn.hippo4j.common.toolkit.UserContext;
-import cn.hippo4j.common.toolkit.http.HttpUtil;
 import cn.hippo4j.common.model.Result;
 import cn.hippo4j.server.common.base.Results;
 import cn.hippo4j.config.model.biz.adapter.ThreadPoolAdapterReqDTO;
 import cn.hippo4j.config.model.biz.adapter.ThreadPoolAdapterRespDTO;
-import cn.hippo4j.config.model.biz.threadpool.ConfigModifySaveReqDTO;
 import cn.hippo4j.config.service.ThreadPoolAdapterService;
-import cn.hippo4j.config.verify.ConfigModificationVerifyServiceChoose;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,8 +42,6 @@ public class ThreadPoolAdapterController {
 
     private final ThreadPoolAdapterService threadPoolAdapterService;
 
-    private final ConfigModificationVerifyServiceChoose configModificationVerifyServiceChoose;
-
     @GetMapping(REGISTER_ADAPTER_BASE_PATH + "/query")
     public Result<List<ThreadPoolAdapterRespDTO>> queryAdapterThreadPool(ThreadPoolAdapterReqDTO requestParameter) {
         List<ThreadPoolAdapterRespDTO> result = threadPoolAdapterService.query(requestParameter);
@@ -65,20 +56,7 @@ public class ThreadPoolAdapterController {
 
     @PostMapping(REGISTER_ADAPTER_BASE_PATH + "/update")
     public Result<Void> updateAdapterThreadPool(@RequestBody ThreadPoolAdapterReqDTO requestParameter) {
-        if (UserContext.getUserRole().equals("ROLE_ADMIN")) {
-            for (String each : requestParameter.getClientAddressList()) {
-                String urlString = StringUtil.newBuilder("http://", each, "/adapter/thread-pool/update");
-                HttpUtil.post(urlString, requestParameter);
-            }
-        } else {
-            ConfigModifySaveReqDTO modifySaveReqDTO = BeanUtil.convert(requestParameter, ConfigModifySaveReqDTO.class);
-            modifySaveReqDTO.setModifyUser(UserContext.getUserName());
-            modifySaveReqDTO.setTenantId(requestParameter.getTenant());
-            modifySaveReqDTO.setItemId(requestParameter.getItem());
-            modifySaveReqDTO.setTpId(requestParameter.getThreadPoolKey());
-            modifySaveReqDTO.setType(ConfigModifyTypeConstants.ADAPTER_THREAD_POOL);
-            configModificationVerifyServiceChoose.choose(modifySaveReqDTO.getType()).saveConfigModifyApplication(modifySaveReqDTO);
-        }
+        threadPoolAdapterService.updateThreadPool(requestParameter);
         return Results.success();
     }
 

--- a/threadpool/server/discovery/src/main/java/cn/hippo4j/discovery/core/BaseInstanceRegistry.java
+++ b/threadpool/server/discovery/src/main/java/cn/hippo4j/discovery/core/BaseInstanceRegistry.java
@@ -19,18 +19,22 @@ package cn.hippo4j.discovery.core;
 
 import cn.hippo4j.common.executor.ThreadFactoryBuilder;
 import cn.hippo4j.common.extension.design.AbstractSubjectCenter;
+import cn.hippo4j.common.constant.Constants;
 import cn.hippo4j.common.model.InstanceInfo;
 import cn.hippo4j.common.model.InstanceInfo.InstanceStatus;
 import cn.hippo4j.common.toolkit.CollectionUtil;
+import cn.hippo4j.common.toolkit.StringUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
+import java.util.Collection;
+import java.util.Objects;
+import java.util.TimerTask;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -152,6 +156,45 @@ public class BaseInstanceRegistry implements InstanceRegistry<InstanceInfo> {
             log.info("Clean up unhealthy nodes. Node id: {}", id);
         }
         return true;
+    }
+
+    /**
+     * obtain whether a client supports rpc
+     *
+     * @param clientAddress address
+     * @return InstanceInfo
+     */
+    public boolean getInstanceSupport(String clientAddress) {
+        return registry.values().stream().map(Map::values)
+                .flatMap(Collection::stream)
+                .map(Lease::getHolder)
+                .filter(Objects::nonNull)
+                .anyMatch(i -> {
+                    String s = StringUtil.subBefore(i.getIdentify(), Constants.IDENTIFY_SLICER_SYMBOL);
+                    return (Objects.equals(clientAddress, s) || Objects.equals(clientAddress, i.getCallBackUrl()))
+                            && i.getEnableRpc();
+                });
+    }
+
+    /**
+     * get server address
+     *
+     * @param clientAddress address
+     * @return address
+     */
+    public String getInstanceCallUrl(String clientAddress) {
+        return registry.values().stream().map(Map::values)
+                .flatMap(Collection::stream)
+                .map(Lease::getHolder)
+                .filter(Objects::nonNull)
+                .filter(i -> {
+                    String s = StringUtil.subBefore(i.getIdentify(), Constants.IDENTIFY_SLICER_SYMBOL);
+                    return Objects.equals(clientAddress, s) || Objects.equals(clientAddress, i.getCallBackUrl())
+                            && i.getEnableRpc();
+                })
+                .findFirst()
+                .map(InstanceInfo::getCallBackUrl)
+                .orElse(null);
     }
 
     /**


### PR DESCRIPTION
Changes proposed in this pull request:
- add rpc call switch
- if rpc is enabled,, the client binds additional ports
- if rpc is enabled,, the server calls the client through rpc
- if rpc is enabled, modify the called url and adjust the called port number
- modify the previous call logic to be compatible with the old version
- adjust all input parameters and return values to be serializable

If rpc is not enabled, the original logic will not be affected

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
