### PR TITLE
fix: increase codecov coverage by using junit instead of junit.jupiter

### DIFF
--- a/infra/common/src/test/java/cn/hippo4j/common/MockitoTests.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/MockitoTests.java
@@ -17,25 +17,25 @@
 
 package cn.hippo4j.common;
 
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.List;
-
-@ExtendWith(MockitoExtension.class)
-class MockitoTests {
+@RunWith(MockitoJUnitRunner.class)
+public class MockitoTests {
 
     @Mock
     List<String> list;
 
     @Test
-    void mockTests() {
+    public void mockTests() {
         Mockito.when(list.get(1)).thenReturn("mock success.");
         Assertions.assertEquals("mock success.", list.get(1));
         try (final MockedStatic<StringUtils> mockStatic = Mockito.mockStatic(StringUtils.class)) {

--- a/infra/common/src/test/java/cn/hippo4j/common/executor/support/BlockingQueueTypeEnumTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/executor/support/BlockingQueueTypeEnumTest.java
@@ -18,7 +18,7 @@
 package cn.hippo4j.common.executor.support;
 
 import org.junit.Assert;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +34,7 @@ public final class BlockingQueueTypeEnumTest {
     private static final List<String> BLOCKING_QUEUE_NAMES = Arrays.stream(BlockingQueueTypeEnum.values()).map(BlockingQueueTypeEnum::getName).collect(Collectors.toList());
 
     @Test
-    void assertCreateBlockingQueueNormal() {
+    public void testAssertCreateBlockingQueueNormal() {
         // check legal param: name and capacity
         for (String name : BLOCKING_QUEUE_NAMES) {
             BlockingQueue<Object> blockingQueueByName = BlockingQueueTypeEnum.createBlockingQueue(name, 10);
@@ -43,7 +43,7 @@ public final class BlockingQueueTypeEnumTest {
     }
 
     @Test
-    void assertCreateBlockingQueueWithIllegalName() {
+    public void testAssertCreateBlockingQueueWithIllegalName() {
         // check illegal null name
         Assert.assertNotNull(BlockingQueueTypeEnum.createBlockingQueue(null, 10));
         // check unexistent name
@@ -51,7 +51,7 @@ public final class BlockingQueueTypeEnumTest {
     }
 
     @Test
-    void assertCreateBlockingQueueWithIllegalCapacity() {
+    public void testAssertCreateBlockingQueueWithIllegalCapacity() {
         // check illegal null capacity
         for (String name : BLOCKING_QUEUE_NAMES) {
             BlockingQueue<Object> blockingQueueWithNullCapacity = BlockingQueueTypeEnum.createBlockingQueue(name, null);
@@ -81,14 +81,14 @@ public final class BlockingQueueTypeEnumTest {
     }
 
     @Test
-    void assertCreateBlockingQueueWithIllegalParams() {
+    public void testAssertCreateBlockingQueueWithIllegalParams() {
         // check illegal name and capacity
         Assert.assertNotNull(BlockingQueueTypeEnum.createBlockingQueue("HelloWorld", null));
         Assert.assertNotNull(BlockingQueueTypeEnum.createBlockingQueue(null, null));
     }
 
     @Test
-    void assertCreateBlockingQueueWithType() {
+    public void testAssertCreateBlockingQueueWithType() {
         Assert.assertNotNull(BlockingQueueTypeEnum.createBlockingQueue(1, null));
         Assert.assertNotNull(BlockingQueueTypeEnum.createBlockingQueue(2, null));
         Assert.assertNotNull(BlockingQueueTypeEnum.createBlockingQueue(3, null));
@@ -102,7 +102,7 @@ public final class BlockingQueueTypeEnumTest {
     }
 
     @Test
-    void assertGetBlockingQueueNameByType() {
+    public void testAssertGetBlockingQueueNameByType() {
         // check legal range of type
         Assert.assertEquals("ArrayBlockingQueue", BlockingQueueTypeEnum.getBlockingQueueNameByType(1));
         Assert.assertEquals("LinkedBlockingQueue", BlockingQueueTypeEnum.getBlockingQueueNameByType(2));
@@ -118,7 +118,7 @@ public final class BlockingQueueTypeEnumTest {
     }
 
     @Test
-    void assertGetBlockingQueueTypeEnumByName() {
+    public void testAssertGetBlockingQueueTypeEnumByName() {
         // check legal range of name
         Assert.assertEquals(BlockingQueueTypeEnum.ARRAY_BLOCKING_QUEUE, BlockingQueueTypeEnum.getBlockingQueueTypeEnumByName("ArrayBlockingQueue"));
         Assert.assertEquals(BlockingQueueTypeEnum.LINKED_BLOCKING_QUEUE, BlockingQueueTypeEnum.getBlockingQueueTypeEnumByName("LinkedBlockingQueue"));

--- a/infra/common/src/test/java/cn/hippo4j/common/executor/support/RejectedPolicyTypeEnumTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/executor/support/RejectedPolicyTypeEnumTest.java
@@ -17,18 +17,18 @@
 
 package cn.hippo4j.common.executor.support;
 
+import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
 /**
  * test for {@link RejectedPolicyTypeEnum}
  */
-class RejectedPolicyTypeEnumTest {
+public class RejectedPolicyTypeEnumTest {
 
     @Test
-    void testGetType() {
+    public void testGetType() {
         Assertions.assertEquals(1, RejectedPolicyTypeEnum.CALLER_RUNS_POLICY.getType());
         Assertions.assertEquals(2, RejectedPolicyTypeEnum.ABORT_POLICY.getType());
         Assertions.assertEquals(3, RejectedPolicyTypeEnum.DISCARD_POLICY.getType());
@@ -38,7 +38,7 @@ class RejectedPolicyTypeEnumTest {
     }
 
     @Test
-    void testGetName() {
+    public void testGetName() {
         Assertions.assertEquals("CallerRunsPolicy", RejectedPolicyTypeEnum.CALLER_RUNS_POLICY.getName());
         Assertions.assertEquals("AbortPolicy", RejectedPolicyTypeEnum.ABORT_POLICY.getName());
         Assertions.assertEquals("DiscardPolicy", RejectedPolicyTypeEnum.DISCARD_POLICY.getName());
@@ -48,12 +48,12 @@ class RejectedPolicyTypeEnumTest {
     }
 
     @Test
-    void testValues() {
+    public void testValues() {
         Assertions.assertNotNull(RejectedPolicyTypeEnum.values());
     }
 
     @Test
-    void testValueOf() {
+    public void testValueOf() {
         Assertions.assertEquals(RejectedPolicyTypeEnum.CALLER_RUNS_POLICY, RejectedPolicyTypeEnum.valueOf("CALLER_RUNS_POLICY"));
         Assertions.assertEquals(RejectedPolicyTypeEnum.ABORT_POLICY, RejectedPolicyTypeEnum.valueOf("ABORT_POLICY"));
         Assertions.assertEquals(RejectedPolicyTypeEnum.DISCARD_POLICY, RejectedPolicyTypeEnum.valueOf("DISCARD_POLICY"));
@@ -63,7 +63,7 @@ class RejectedPolicyTypeEnumTest {
     }
 
     @Test
-    void testCreatePolicy() {
+    public void testCreatePolicy() {
         // check legal param: name and type
         Arrays.stream(RejectedPolicyTypeEnum.values()).forEach(each -> {
             Assertions.assertNotNull(RejectedPolicyTypeEnum.createPolicy(each.getName()));
@@ -78,19 +78,17 @@ class RejectedPolicyTypeEnumTest {
     }
 
     @Test
-    void testGetRejectedNameByType() {
+    public void testGetRejectedNameByType() {
         // check legal range of type
-        Arrays.stream(RejectedPolicyTypeEnum.values()).forEach(each ->
-                Assertions.assertEquals(each.getName(), RejectedPolicyTypeEnum.getRejectedNameByType(each.getType())));
+        Arrays.stream(RejectedPolicyTypeEnum.values()).forEach(each -> Assertions.assertEquals(each.getName(), RejectedPolicyTypeEnum.getRejectedNameByType(each.getType())));
         // check illegal range of type
         Assertions.assertEquals("AbortPolicy", RejectedPolicyTypeEnum.getRejectedNameByType(-1));
     }
 
     @Test
-    void testGetRejectedPolicyTypeEnumByName() {
+    public void testGetRejectedPolicyTypeEnumByName() {
         // check legal range of name
-        Arrays.stream(RejectedPolicyTypeEnum.values()).forEach(each ->
-                Assertions.assertEquals(each, RejectedPolicyTypeEnum.getRejectedPolicyTypeEnumByName(each.getName())));
+        Arrays.stream(RejectedPolicyTypeEnum.values()).forEach(each -> Assertions.assertEquals(each, RejectedPolicyTypeEnum.getRejectedPolicyTypeEnumByName(each.getName())));
         // check illegal name
         Assertions.assertEquals(RejectedPolicyTypeEnum.ABORT_POLICY,
                 RejectedPolicyTypeEnum.getRejectedPolicyTypeEnumByName("XXX"));

--- a/infra/common/src/test/java/cn/hippo4j/common/function/NoArgsConsumerTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/function/NoArgsConsumerTest.java
@@ -19,14 +19,14 @@ package cn.hippo4j.common.function;
 
 import cn.hippo4j.common.extension.function.NoArgsConsumer;
 import cn.hippo4j.common.toolkit.Assert;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-final class NoArgsConsumerTest {
+public final class NoArgsConsumerTest {
 
     @Test
-    void accept() {
+    public void accept() {
         AtomicBoolean checkValue = new AtomicBoolean(false);
         NoArgsConsumer noArgsConsumer = () -> checkValue.set(true);
         noArgsConsumer.accept();

--- a/infra/common/src/test/java/cn/hippo4j/common/toolkit/UserContextTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/toolkit/UserContextTest.java
@@ -17,7 +17,7 @@
 
 package cn.hippo4j.common.toolkit;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class UserContextTest {
 

--- a/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java
@@ -18,46 +18,46 @@
 package cn.hippo4j.common.toolkit.logtracing;
 
 import org.apache.logging.log4j.util.Strings;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class LogMessageTest {
+public class LogMessageTest {
 
     private final static String MESSAGE = "message";
     private final static String THROWABLE_MESSAGE = "throwable message";
 
     private LogMessage logMessage;
 
-    @BeforeEach
+    @Before
     public void init() {
         logMessage = LogMessage.getInstance();
     }
 
     @Test
-    void testGetInstanceShouldReturnANewLogMessageInstance() {
+    public void testGetInstanceShouldReturnANewLogMessageInstance() {
         final LogMessage newInstance = LogMessage.getInstance();
         assertNotNull(newInstance);
         assertNotSame(logMessage, newInstance);
     }
 
     @Test
-    void testToStringShouldHaveAnEmptyMessage() {
+    public void testToStringShouldHaveAnEmptyMessage() {
         assertEquals(Strings.EMPTY, logMessage.toString());
     }
 
     @Test
-    void testSetMsgShouldSetAnewMessageInLogMessage() {
+    public void testSetMsgShouldSetAnewMessageInLogMessage() {
         logMessage.setMsg(MESSAGE);
         assertEquals(MESSAGE, logMessage.toString());
     }
 
     @Test
-    void testMsgShouldContainsMessageAndThrowableMessage() {
+    public void testMsgShouldContainsMessageAndThrowableMessage() {
         final String message = logMessage.msg(MESSAGE, new Throwable(THROWABLE_MESSAGE));
         assertNotNull(message);
         assertTrue(message.contains(MESSAGE));
@@ -65,20 +65,20 @@ class LogMessageTest {
     }
 
     @Test
-    void testKvShouldPutKeyAndValue() {
+    public void testKvShouldPutKeyAndValue() {
         logMessage.kv("key", "value");
         assertEquals("key=value", logMessage.toString());
     }
 
     @Test
-    void testKvShouldPutAllKeyAndValuePairs() {
+    public void testKvShouldPutAllKeyAndValuePairs() {
         logMessage.kv("key1", "value1");
         logMessage.kv("key2", "value2");
         assertEquals("key1=value1||key2=value2", logMessage.toString());
     }
 
     @Test
-    void testToStringShouldPrintMessageAndAllKeyAndValuePairs() {
+    public void testToStringShouldPrintMessageAndAllKeyAndValuePairs() {
         logMessage.setMsg(MESSAGE);
         logMessage.kv("key1", "value1");
         logMessage.kv("key2", "value2");
@@ -86,7 +86,7 @@ class LogMessageTest {
     }
 
     @Test
-    void testKv2StringShouldPrintMessageAndAllKeyAndValuePairs() {
+    public void testKv2StringShouldPrintMessageAndAllKeyAndValuePairs() {
         String result = logMessage.kv2String("key", "value");
         assertEquals("key=value", result);
     }

--- a/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java
@@ -30,7 +30,6 @@ public class LogMessageTest {
 
     private final static String MESSAGE = "message";
     private final static String THROWABLE_MESSAGE = "throwable message";
-
     private LogMessage logMessage;
 
     @Before

--- a/threadpool/core/src/test/java/cn/hippo4j/core/executor/state/AbstractThreadPoolRuntimeTest.java
+++ b/threadpool/core/src/test/java/cn/hippo4j/core/executor/state/AbstractThreadPoolRuntimeTest.java
@@ -17,24 +17,24 @@
 
 package cn.hippo4j.core.executor.state;
 
-import cn.hippo4j.common.model.ThreadPoolRunStateInfo;
-import cn.hippo4j.core.executor.DynamicThreadPoolExecutor;
-import cn.hippo4j.core.executor.DynamicThreadPoolWrapper;
-import cn.hippo4j.core.executor.manage.GlobalThreadPoolManage;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-@ExtendWith(MockitoExtension.class)
+import cn.hippo4j.common.model.ThreadPoolRunStateInfo;
+import cn.hippo4j.core.executor.DynamicThreadPoolExecutor;
+import cn.hippo4j.core.executor.DynamicThreadPoolWrapper;
+import cn.hippo4j.core.executor.manage.GlobalThreadPoolManage;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
 public class AbstractThreadPoolRuntimeTest {
 
     @Test
-    void testPoolRunState() {
+    public void testPoolRunState() {
         AbstractThreadPoolRuntime threadPoolRuntime = new AbstractThreadPoolRuntime() {
 
             @Override

--- a/threadpool/server/auth/src/test/java/cn/hippo4j/auth/filter/JWTAuthenticationFilterTest.java
+++ b/threadpool/server/auth/src/test/java/cn/hippo4j/auth/filter/JWTAuthenticationFilterTest.java
@@ -18,15 +18,15 @@
 package cn.hippo4j.auth.filter;
 
 import cn.hippo4j.common.toolkit.ReflectUtil;
+import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
-class JWTAuthenticationFilterTest {
+public class JWTAuthenticationFilterTest {
 
     @Test
-    void getMessageTest() {
+    public void getMessageTest() {
         JWTAuthenticationFilter filter = new JWTAuthenticationFilter(null);
         Assertions.assertEquals("用户不存在", ReflectUtil.invoke(filter,
                 "getMessage", new UsernameNotFoundException("")));

--- a/threadpool/server/auth/src/test/java/cn/hippo4j/auth/service/impl/UserServiceImplTest.java
+++ b/threadpool/server/auth/src/test/java/cn/hippo4j/auth/service/impl/UserServiceImplTest.java
@@ -18,12 +18,12 @@
 package cn.hippo4j.auth.service.impl;
 
 import org.junit.Assert;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
-class UserServiceImplTest {
+public class UserServiceImplTest {
 
     @Test
-    void checkPasswordLength() {
+    public void testCheckPasswordLength() {
         // 密码为null、空串、过短、过长都会抛出异常
         UserServiceImpl userService = new UserServiceImpl(null, null, null);
         Assert.assertThrows(RuntimeException.class, () -> userService.checkPasswordLength(null));

--- a/threadpool/server/auth/src/test/java/cn/hippo4j/auth/toolkit/JwtTokenUtilTest.java
+++ b/threadpool/server/auth/src/test/java/cn/hippo4j/auth/toolkit/JwtTokenUtilTest.java
@@ -18,8 +18,8 @@
 package cn.hippo4j.auth.toolkit;
 
 import cn.hippo4j.common.toolkit.Assert;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 
 public final class JwtTokenUtilTest {
 
@@ -33,7 +33,7 @@ public final class JwtTokenUtilTest {
 
     private String token;
 
-    @BeforeEach
+    @Before
     public void setUp() {
         token = JwtTokenUtil.createToken(userId, username, role, isRememberMe);
     }

--- a/threadpool/server/common/src/test/java/cn/hippo4j/server/common/base/ResultsTest.java
+++ b/threadpool/server/common/src/test/java/cn/hippo4j/server/common/base/ResultsTest.java
@@ -21,7 +21,7 @@ import cn.hippo4j.common.model.Result;
 import cn.hippo4j.common.toolkit.Assert;
 import cn.hippo4j.server.common.base.exception.AbstractException;
 import cn.hippo4j.server.common.base.exception.ErrorCode;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import static cn.hippo4j.server.common.base.exception.ErrorCodeEnum.SERVICE_ERROR;
 


### PR DESCRIPTION
Fixes: as noticed, codecov coverage is not taking in consideration some of the test classes.

Changes proposed in this pull request:
- Use org.junit instead of junit.jupiter api to make these classes viewable in codecov

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
