### PR TITLE
@EnableDynamicThreadPool controls MicrometerMonitorAutoConfiguration

### DIFF
--- a/hippo4j-spring-boot/hippo4j-spring-boot-starter-monitor/hippo4j-spring-boot-starter-monitor-micrometer/src/main/java/cn/hippo4j/springboot/starter/monitor/micrometer/MicrometerMonitorAutoConfiguration.java
+++ b/hippo4j-spring-boot/hippo4j-spring-boot-starter-monitor/hippo4j-spring-boot-starter-monitor-micrometer/src/main/java/cn/hippo4j/springboot/starter/monitor/micrometer/MicrometerMonitorAutoConfiguration.java
@@ -17,10 +17,13 @@
 
 package cn.hippo4j.springboot.starter.monitor.micrometer;
 
+import cn.hippo4j.core.enable.MarkerConfiguration;
 import cn.hippo4j.monitor.micrometer.AdapterThreadPoolMicrometerMonitorHandler;
 import cn.hippo4j.monitor.micrometer.DynamicThreadPoolMicrometerMonitorHandler;
 import cn.hippo4j.monitor.micrometer.WebThreadPoolMicrometerMonitorHandler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,6 +31,8 @@ import org.springframework.context.annotation.Configuration;
  * Micrometer monitor auto configuration.
  */
 @Configuration
+@ConditionalOnBean(MarkerConfiguration.Marker.class)
+@ConditionalOnProperty(prefix = "spring.dynamic.thread-pool", value = "enable", matchIfMissing = true, havingValue = "true")
 @ConditionalOnExpression("'${spring.dynamic.thread-pool.monitor.collect-types:}'.contains('micrometer')")
 public class MicrometerMonitorAutoConfiguration {
 


### PR DESCRIPTION
Fixes #1371 

Changes proposed in this pull request:
-  @EnableDynamicThreadPool controls MicrometerMonitorAutoConfiguration

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
