### PR TITLE
@EnableDynamicThreadPool controls MicrometerMonitorAutoConfiguration

### DIFF
--- a/starters/threadpool/monitor/hippo4j-spring-boot-starter-monitor-elasticsearch/src/main/java/cn/hippo4j/springboot/starter/monitor/elasticsearch/ElasticSearchMonitorAutoConfiguration.java
+++ b/starters/threadpool/monitor/hippo4j-spring-boot-starter-monitor-elasticsearch/src/main/java/cn/hippo4j/springboot/starter/monitor/elasticsearch/ElasticSearchMonitorAutoConfiguration.java
@@ -18,9 +18,11 @@
 package cn.hippo4j.springboot.starter.monitor.elasticsearch;
 
 import cn.hippo4j.common.constant.Constants;
+import cn.hippo4j.core.enable.MarkerConfiguration;
 import cn.hippo4j.monitor.elasticsearch.AdapterThreadPoolElasticSearchMonitorHandler;
 import cn.hippo4j.monitor.elasticsearch.DynamicThreadPoolElasticSearchMonitorHandler;
 import cn.hippo4j.monitor.elasticsearch.WebThreadPoolElasticSearchMonitorHandler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +32,7 @@ import org.springframework.context.annotation.Configuration;
  * Elastic-search monitor auto configuration.
  */
 @Configuration
+@ConditionalOnBean(MarkerConfiguration.Marker.class)
 @ConditionalOnExpression("'${spring.dynamic.thread-pool.monitor.collect-types:}'.contains('elasticsearch')")
 @ConditionalOnProperty(prefix = Constants.CONFIGURATION_PROPERTIES_PREFIX, value = "enable", matchIfMissing = true, havingValue = "true")
 public class ElasticSearchMonitorAutoConfiguration {

--- a/starters/threadpool/monitor/hippo4j-spring-boot-starter-monitor-local-log/src/main/java/cn/hippo4j/springboot/starter/monitor/local/log/LocalLogMonitorAutoConfiguration.java
+++ b/starters/threadpool/monitor/hippo4j-spring-boot-starter-monitor-local-log/src/main/java/cn/hippo4j/springboot/starter/monitor/local/log/LocalLogMonitorAutoConfiguration.java
@@ -19,6 +19,7 @@ package cn.hippo4j.springboot.starter.monitor.local.log;
 
 import cn.hippo4j.adapter.web.WebThreadPoolService;
 import cn.hippo4j.common.constant.Constants;
+import cn.hippo4j.core.enable.MarkerConfiguration;
 import cn.hippo4j.monitor.local.log.AdapterThreadPoolLocalLogMonitorHandler;
 import cn.hippo4j.monitor.local.log.DynamicThreadPoolLocalLogMonitorHandler;
 import cn.hippo4j.monitor.local.log.WebThreadPoolLocalLogMonitorHandler;
@@ -32,6 +33,7 @@ import org.springframework.context.annotation.Configuration;
  * Local log monitor auto configuration.
  */
 @Configuration
+@ConditionalOnBean(MarkerConfiguration.Marker.class)
 @ConditionalOnExpression("'${spring.dynamic.thread-pool.monitor.collect-types:}'.contains('log')")
 @ConditionalOnProperty(prefix = Constants.CONFIGURATION_PROPERTIES_PREFIX, value = "enable", matchIfMissing = true, havingValue = "true")
 public class LocalLogMonitorAutoConfiguration {

--- a/starters/threadpool/monitor/hippo4j-spring-boot-starter-monitor-micrometer/src/main/java/cn/hippo4j/springboot/starter/monitor/micrometer/MicrometerMonitorAutoConfiguration.java
+++ b/starters/threadpool/monitor/hippo4j-spring-boot-starter-monitor-micrometer/src/main/java/cn/hippo4j/springboot/starter/monitor/micrometer/MicrometerMonitorAutoConfiguration.java
@@ -19,6 +19,7 @@ package cn.hippo4j.springboot.starter.monitor.micrometer;
 
 import cn.hippo4j.adapter.web.WebThreadPoolService;
 import cn.hippo4j.common.constant.Constants;
+import cn.hippo4j.core.enable.MarkerConfiguration;
 import cn.hippo4j.monitor.micrometer.AdapterThreadPoolMicrometerMonitorHandler;
 import cn.hippo4j.monitor.micrometer.DynamicThreadPoolMicrometerMonitorHandler;
 import cn.hippo4j.monitor.micrometer.WebThreadPoolMicrometerMonitorHandler;
@@ -32,6 +33,7 @@ import org.springframework.context.annotation.Configuration;
  * Micrometer monitor auto configuration.
  */
 @Configuration
+@ConditionalOnBean(MarkerConfiguration.Marker.class)
 @ConditionalOnExpression("'${spring.dynamic.thread-pool.monitor.collect-types:}'.contains('micrometer')")
 @ConditionalOnProperty(prefix = Constants.CONFIGURATION_PROPERTIES_PREFIX, value = "enable", matchIfMissing = true, havingValue = "true")
 public class MicrometerMonitorAutoConfiguration {


### PR DESCRIPTION
Fixes https://github.com/opengoofy/hippo4j/issues/1371

Changes proposed in this pull request:
- @EnableDynamicThreadPool controls MicrometerMonitorAutoConfiguration

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
