### PR TITLE
Reconfiguration ThreadPoolExecutor

### DIFF
--- a/infra/common/src/test/java/cn/hippo4j/common/executor/support/ThreadPoolExecutorUtilTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/executor/support/ThreadPoolExecutorUtilTest.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;

--- a/infra/common/src/test/java/cn/hippo4j/common/executor/support/ThreadPoolExecutorUtilTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/executor/support/ThreadPoolExecutorUtilTest.java
@@ -82,7 +82,6 @@ public class ThreadPoolExecutorUtilTest {
 
     @Test
     public void testException(){
-        // Test n
         int newCorePoolSize4 = 6;
         int newMaxPoolSize4 = 4;
         try {

--- a/infra/common/src/test/java/cn/hippo4j/common/executor/support/ThreadPoolExecutorUtilTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/executor/support/ThreadPoolExecutorUtilTest.java
@@ -1,0 +1,83 @@
+package cn.hippo4j.common.executor.support;
+
+import cn.hippo4j.common.toolkit.ThreadPoolExecutorUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Shizi
+ * @version 1.0
+ * Create by 2023-07-29 18:43
+ */
+@Slf4j
+public class ThreadPoolExecutorUtilTest {
+
+    private ThreadPoolExecutor executor;
+    private int corePoolSize;
+    private int maxPoolSize;
+
+    @Before
+    public void testSafeSetPoolSize() {
+        corePoolSize = 2;
+        maxPoolSize = 4;
+        executor = new ThreadPoolExecutor(
+                corePoolSize,
+                maxPoolSize,
+                1L,
+                TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(10)
+        );
+    }
+
+    @Test
+    public void testEquals(){
+        // Test when the new core pool size equals the original maximum pool size.
+        int newCorePoolSize1 = maxPoolSize;
+        int newMaxPoolSize1 = 6;
+        ThreadPoolExecutorUtil.safeSetPoolSize(executor, newCorePoolSize1, newMaxPoolSize1);
+        Assert.assertEquals(newCorePoolSize1, executor.getCorePoolSize());
+        Assert.assertEquals(newMaxPoolSize1, executor.getMaximumPoolSize());
+    }
+
+    @Test
+    public void testGreater(){
+        // Test when the new core pool size is greater than the original maximum pool size.
+        int newCorePoolSize2 = 8;
+        int newMaxPoolSize2 = 10;
+        ThreadPoolExecutorUtil.safeSetPoolSize(executor, newCorePoolSize2, newMaxPoolSize2);
+        Assert.assertEquals(newCorePoolSize2, executor.getCorePoolSize());
+        Assert.assertEquals(newMaxPoolSize2, executor.getMaximumPoolSize());
+    }
+
+    @Test
+    public void testLess(){
+        // Test when the new core pool size is less than the original maximum pool size.
+        int newCorePoolSize3 = 3;
+        int newMaxPoolSize3 = 5;
+        ThreadPoolExecutorUtil.safeSetPoolSize(executor, newCorePoolSize3, newMaxPoolSize3);
+        Assert.assertEquals(newCorePoolSize3, executor.getCorePoolSize());
+        Assert.assertEquals(newMaxPoolSize3, executor.getMaximumPoolSize());
+    }
+
+    @Test
+    public void testException(){
+        // Test when the new core pool size is greater than the new maximum pool size, which should throw an IllegalArgumentException.
+        int newCorePoolSize4 = 6;
+        int newMaxPoolSize4 = 4;
+        try {
+            ThreadPoolExecutorUtil.safeSetPoolSize(executor, newCorePoolSize4, newMaxPoolSize4);
+        } catch (IllegalArgumentException e) {
+            // Expected to throw an exception.
+            Assert.assertEquals("newCorePoolSize must be smaller than newMaximumPoolSize", e.getMessage());
+            log.error("newCorePoolSize must be smaller than newMaximumPoolSize",e.getMessage());
+        }
+    }
+}
+

--- a/infra/common/src/test/java/cn/hippo4j/common/executor/support/ThreadPoolExecutorUtilTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/executor/support/ThreadPoolExecutorUtilTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package cn.hippo4j.common.executor.support;
 
 import cn.hippo4j.common.toolkit.ThreadPoolExecutorUtil;
@@ -11,9 +28,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
- * @author Shizi
- * @version 1.0
- * Create by 2023-07-29 18:43
+ * ThreadPoolExecutor test class
  */
 @Slf4j
 public class ThreadPoolExecutorUtilTest {
@@ -67,7 +82,7 @@ public class ThreadPoolExecutorUtilTest {
 
     @Test
     public void testException(){
-        // Test when the new core pool size is greater than the new maximum pool size, which should throw an IllegalArgumentException.
+        // Test n
         int newCorePoolSize4 = 6;
         int newMaxPoolSize4 = 4;
         try {

--- a/infra/common/src/test/java/cn/hippo4j/common/executor/support/ThreadPoolExecutorUtilTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/executor/support/ThreadPoolExecutorUtilTest.java
@@ -50,6 +50,7 @@ public class ThreadPoolExecutorUtilTest {
         );
     }
 
+
     @Test
     public void testEquals(){
         // Test when the new core pool size equals the original maximum pool size.


### PR DESCRIPTION
Fixes #1405 

Changes proposed in this pull request:
- Refactoring throws an exception when the newly set number of core threads exceeds the maximum number of threads

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
