### PR TITLE
Remove the redundant comment for CalculateUtil

### DIFF
--- a/infra/common/src/main/java/cn/hippo4j/common/toolkit/CalculateUtil.java
+++ b/infra/common/src/main/java/cn/hippo4j/common/toolkit/CalculateUtil.java
@@ -19,9 +19,6 @@ package cn.hippo4j.common.toolkit;
 
 /**
  * Calculate util.
- *
- * @author chen.ma
- * @date 2021/8/15 14:29
  */
 public class CalculateUtil {
 


### PR DESCRIPTION
Fixes #1395 

Changes proposed in this pull request:
- Remove the redundant comment for CalculateUtil


