### PR TITLE
check the required fields apollo when the Config mode starts

### DIFF
--- a/kernel/dynamic/api/src/main/java/cn/hippo4j/threadpool/dynamic/api/BootstrapPropertiesInterface.java
+++ b/kernel/dynamic/api/src/main/java/cn/hippo4j/threadpool/dynamic/api/BootstrapPropertiesInterface.java
@@ -86,4 +86,12 @@ public interface BootstrapPropertiesInterface {
     default Map<String, String> getEtcd() {
         return null;
     }
+
+    /**
+     * Get apollo.
+     */
+    default  Map<String, String> getApollo(){
+        return null;
+    }
+
 }

--- a/threadpool/core/src/main/java/cn/hippo4j/core/enable/BeforeCheckConfiguration.java
+++ b/threadpool/core/src/main/java/cn/hippo4j/core/enable/BeforeCheckConfiguration.java
@@ -105,6 +105,16 @@ public class BeforeCheckConfiguration {
                                     "Please check whether the [spring.dynamic.thread-pool.etcd.key] configuration is empty or an empty string.");
                         }
                     }
+
+                    Map<String, String> apollo = properties.getApollo();
+                    if (MapUtil.isNotEmpty(apollo)) {
+                        String namespace = apollo.get("namespace");
+                        if (StringUtil.isBlank(namespace)) {
+                            throw new ConfigEmptyException(
+                                    "Web server failed to start. The dynamic thread pool apollo namespace is empty.",
+                                    "Please check whether the [spring.dynamic.thread-pool.apollo.namespace] configuration is empty or an empty string.");
+                        }
+                    }
                     break;
                 }
                 default:


### PR DESCRIPTION
#1439

Changes proposed in this pull request:
-  Check the required fields apollo when the Config mode starts

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
