### PR TITLE
Fix flaky test in Md5UtilTest

### DIFF
--- a/infra/common/src/test/java/cn/hippo4j/common/toolkit/Md5UtilTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/toolkit/Md5UtilTest.java
@@ -19,11 +19,17 @@ package cn.hippo4j.common.toolkit;
 
 import cn.hippo4j.common.model.ThreadPoolParameterInfo;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.mockStatic;
 
 public class Md5UtilTest {
 
@@ -50,12 +56,15 @@ public class Md5UtilTest {
 
     @Test
     public void assetGetTpContentMd5() {
-        String md5Result = "ef5ea7cb47377fb9fb85a7125e76715d";
-        ThreadPoolParameterInfo threadPoolParameterInfo = ThreadPoolParameterInfo.builder().tenantId("prescription")
-                .itemId("dynamic-threadpool-example").tpId("message-consume").content("描述信息").corePoolSize(1)
-                .maximumPoolSize(2).queueType(1).capacity(4).keepAliveTime(513L).executeTimeOut(null).rejectedType(4)
-                .isAlarm(1).capacityAlarm(80).livenessAlarm(80).allowCoreThreadTimeOut(1).build();
-        Assert.isTrue(md5Result.equals(Md5Util.getTpContentMd5(threadPoolParameterInfo)));
+        final ThreadPoolParameterInfo threadPoolParameterInfo = new ThreadPoolParameterInfo();
+        final String mockContent = "mockContent";
+        final String mockContentMd5 = "34cf17bc632ece6e4c81a4ce8aa97d5e";
+        try (final MockedStatic<ContentUtil> mockedContentUtil = mockStatic(ContentUtil.class)) {
+            mockedContentUtil.when(() -> ContentUtil.getPoolContent(threadPoolParameterInfo)).thenReturn(mockContent);
+            final String result = Md5Util.getTpContentMd5(threadPoolParameterInfo);
+            Assert.isTrue(result.equals(mockContentMd5));
+            mockedContentUtil.verify(() -> ContentUtil.getPoolContent(threadPoolParameterInfo), times(1));
+        }
     }
 
     @Test

--- a/infra/common/src/test/java/cn/hippo4j/common/toolkit/Md5UtilTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/toolkit/Md5UtilTest.java
@@ -19,9 +19,7 @@ package cn.hippo4j.common.toolkit;
 
 import cn.hippo4j.common.model.ThreadPoolParameterInfo;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;


### PR DESCRIPTION
Updated a flaky test case in Md5UtilTest to avoid making internal function calls thus making it not flaky.

**Flaky test case:** cn.hippo4j.common.toolkit.Md5UtilTest.assetGetTpContentMd5
https://github.com/opengoofy/hippo4j/blob/472d345285167e853af313e55980fdb541292e75/infra/common/src/test/java/cn/hippo4j/common/toolkit/Md5UtilTest.java#L52

### Problem

Test ```assetGetTpContentMd5``` in ```Md5UtilTest``` is detected as flaky with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed with the following error:


```
[ERROR] Errors: 
[ERROR]   Md5UtilTest.assetGetTpContentMd5:58 » IllegalArgument [Assertion failed] - this expression must be true
```


### Root cause

In this test, an object of class [ThreadPoolParameterInfo](https://github.com/opengoofy/hippo4j/blob/develop/infra/common/src/main/java/cn/hippo4j/common/model/ThreadPoolParameterInfo.java) is created and Md5Util.getTpContentMd5() is called with this object. Then the result is compared with a hardcoded string "md5Result"(ef5ea7cb47377fb9fb85a7125e76715d) here 

https://github.com/opengoofy/hippo4j/blob/472d345285167e853af313e55980fdb541292e75/infra/common/src/test/java/cn/hippo4j/common/toolkit/Md5UtilTest.java#L58

During the execution, at one point here 

https://github.com/opengoofy/hippo4j/blob/472d345285167e853af313e55980fdb541292e75/infra/common/src/main/java/cn/hippo4j/common/toolkit/ContentUtil.java#L51

the object is converted to a JSON string using JSONUtil.toJSONString() which internally uses Jackson library ObjectMapper to convert the object to string. But, since the order of properties is not preserved, we get the JSON string with different order of properties each time and this is making this test flaky. Due to different JSON string values, final md5 string value is also different thus making this test flaky.


### Fix

Ideally, a unit test should test the functionality of the method and not the functionalities of the methods called from inside this method. Therefore, we need to mock all the internal calls and test only the functionality of the method. I mocked ContentUtil class (static class) and tested only the Md5Util functionality. This way, the problem mentioned in the above root cause section is avoided and this test doesn't become flaky anymore.



### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl infra/common -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl infra/common test -Dtest=cn.hippo4j.common.toolkit.Md5UtilTest#assetGetTpContentMd5
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl infra/common edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=cn.hippo4j.common.toolkit.Md5UtilTest#assetGetTpContentMd5
```

NonDex test passed after the fix.