### PR TITLE
Fix flaky test in LogMessageTest

### DIFF
--- a/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java
+++ b/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java
@@ -82,7 +82,8 @@ public class LogMessageTest {
         logMessage.setMsg(MESSAGE);
         logMessage.kv("key1", "value1");
         logMessage.kv("key2", "value2");
-        assertEquals("messagekey1=value1||key2=value2", logMessage.toString());
+        String output = logMessage.toString();
+        assertTrue(output.equals("messagekey1=value1||key2=value2") || output.equals("messagekey2=value2||key1=value1"));
     }
 
     @Test


### PR DESCRIPTION
Change Assert condition to check on both map orders in a flaky test in LogMessageTest to make it non-flaky.

**Flaky test**

```
cn.hippo4j.common.toolkit.logtracing.LogMessageTest.testToStringShouldPrintMessageAndAllKeyAndValuePairs
```

https://github.com/opengoofy/hippo4j/blob/fec58a5ecaca0f749abcdf076f13d6f0ba6267b2/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java#L81

### Problem

Test ```testToStringShouldPrintMessageAndAllKeyAndValuePairs``` in ```LogMessageTest``` is detected as flaky with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed with the following error:

```
Error:
Failed tests:   testToStringShouldPrintMessageAndAllKeyAndValuePairs(cn.hippo4j.common.toolkit.logtracing.LogMessageTest): expected: <messagekey1=value1||key2=value2> but was: <messagekey2=value2||key1=value1>
```

### Root cause

In this test, 2 key-value pairs are set to the ```kvs``` field (ConcurrentHashMap) of ```logMessage``` object along with s string message. Then, ```logMessage.toString()``` is called and the response is compared with hard-coded strings. logMessage.toString() converts the given map to string form along with some other processing. But, ConcurrentHashMap/HashMap may not maintain the order of elements. Therefore, when NonDex tests are run, the order of elements are shuffled and the output is reversed and incorrect thus making the test flaky.

Key-values are inserted this way:

https://github.com/opengoofy/hippo4j/blob/fec58a5ecaca0f749abcdf076f13d6f0ba6267b2/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java#L83-L84

Output is compared this way:

https://github.com/opengoofy/hippo4j/blob/fec58a5ecaca0f749abcdf076f13d6f0ba6267b2/infra/common/src/test/java/cn/hippo4j/common/toolkit/logtracing/LogMessageTest.java#L85

Concurrent HashMap used in LogMessage class:

https://github.com/opengoofy/hippo4j/blob/fec58a5ecaca0f749abcdf076f13d6f0ba6267b2/infra/common/src/main/java/cn/hippo4j/common/toolkit/logtracing/LogMessage.java#L35


### Fix

Usually, switching from HashMap to LinkedHashMap will make tests non-flaky because LinkedHashMap will preserve order of elements. But, we cannot change a ConcurrentHashMap to LinkedHashMap because LinkedHashMap is not thread-safe like ConcurrentHashMap. Therefore, I updated the assert statement to check the output for both the possible orders of elements.

This fix will not affect the code since the change is only made in tests.

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl infra/common -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl infra/common test -Dtest=cn.hippo4j.common.toolkit.logtracing.LogMessageTest#testToStringShouldPrintMessageAndAllKeyAndValuePairs
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl infra/common edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=10 -Dtest=cn.hippo4j.common.toolkit.logtracing.LogMessageTest#testToStringShouldPrintMessageAndAllKeyAndValuePairs

```

NonDex tests passed after the fix.