### PR TITLE
fix：Fix error when adding two or more publishers

### DIFF
--- a/threadpool/server/config/src/main/java/cn/hippo4j/config/notify/NotifyCenter.java
+++ b/threadpool/server/config/src/main/java/cn/hippo4j/config/notify/NotifyCenter.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 /**
  * Unified event notify center.
@@ -43,7 +44,7 @@ public class NotifyCenter {
 
     private DefaultSharePublisher sharePublisher;
 
-    private static EventPublisher eventPublisher = new DefaultPublisher();
+    private static final Supplier<EventPublisher> publisherSupplier = DefaultPublisher::new;
 
     private static BiFunction<Class<? extends AbstractEvent>, Integer, EventPublisher> publisherFactory;
 
@@ -52,7 +53,7 @@ public class NotifyCenter {
     static {
         publisherFactory = (cls, buffer) -> {
             try {
-                EventPublisher publisher = eventPublisher;
+                EventPublisher publisher = publisherSupplier.get();
                 publisher.init(cls, buffer);
                 return publisher;
             } catch (Throwable ex) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Create a new publisher instance for each event instead of repeatedly calling the initialization method on the same instance. Repeated calls to the initialization of the same instance will result in `java.lang.IllegalThreadStateException`.

Because there is currently only one publisher for the project, this problem does not occur, and if you register more than one publisher, there will be a problem.