### PR TITLE
optimization the registerDynamicThreadPool method of the DynamicThreadPoolConfigService class

### DIFF
--- a/starters/threadpool/server/src/main/java/cn/hippo4j/springboot/starter/support/DynamicThreadPoolConfigService.java
+++ b/starters/threadpool/server/src/main/java/cn/hippo4j/springboot/starter/support/DynamicThreadPoolConfigService.java
@@ -62,7 +62,6 @@ public class DynamicThreadPoolConfigService extends AbstractDynamicThreadPoolSer
     @Override
     public ThreadPoolExecutor registerDynamicThreadPool(DynamicThreadPoolRegisterWrapper registerWrapper) {
         ThreadPoolExecutor dynamicThreadPoolExecutor = registerExecutor(registerWrapper);
-        subscribeConfig(registerWrapper);
         putNotifyAlarmConfig(registerWrapper);
         return dynamicThreadPoolExecutor;
     }


### PR DESCRIPTION
Changes proposed in this pull request:
  Delete the duplicate subscription operation here, as the unified subscription change operation has been performed in the postProcessAfterInitialization method of the DynamicThreadPoolPostProcessor class. Keeping this will result in the duplicate registration of callback, causing the thread pool to execute the callback repeatedly when receiving configuration changes.
