### PR TITLE
fix: SPI of the ThreadPoolMonitor

### DIFF
--- a/threadpool/monitor/micrometer/src/main/java/cn/hippo4j/monitor/micrometer/DynamicThreadPoolMicrometerMonitorHandler.java
+++ b/threadpool/monitor/micrometer/src/main/java/cn/hippo4j/monitor/micrometer/DynamicThreadPoolMicrometerMonitorHandler.java
@@ -17,12 +17,14 @@
 
 package cn.hippo4j.monitor.micrometer;
 
+import cn.hippo4j.common.extension.spi.ServiceLoaderRegistry;
 import cn.hippo4j.core.config.ApplicationContextHolder;
 import cn.hippo4j.common.model.ThreadPoolRunStateInfo;
 import cn.hippo4j.common.toolkit.BeanUtil;
 import cn.hippo4j.common.toolkit.CollectionUtil;
 import cn.hippo4j.core.executor.state.ThreadPoolRunStateHandler;
 import cn.hippo4j.monitor.base.AbstractDynamicThreadPoolMonitor;
+import cn.hippo4j.threadpool.monitor.api.ThreadPoolMonitor;
 import cn.hippo4j.threadpool.monitor.support.MonitorTypeEnum;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
@@ -46,6 +48,10 @@ public class DynamicThreadPoolMicrometerMonitorHandler extends AbstractDynamicTh
 
     public DynamicThreadPoolMicrometerMonitorHandler(ThreadPoolRunStateHandler handler) {
         super(handler);
+    }
+
+    static {
+        ServiceLoaderRegistry.register(ThreadPoolMonitor.class);
     }
 
     @Override


### PR DESCRIPTION
Changes proposed in this pull request:
Fix the problem that a custom implementation class of ThreadPoolMonitor cannot be introduced through the SPI mechanism in the ReportingEventExecutor class when the project is started.


