### PR TITLE
fix: fix_checkInConfig

### DIFF
--- a/threadpool/core/src/main/java/cn/hippo4j/core/enable/BeforeCheckConfiguration.java
+++ b/threadpool/core/src/main/java/cn/hippo4j/core/enable/BeforeCheckConfiguration.java
@@ -46,7 +46,7 @@ public class BeforeCheckConfiguration {
         // TODO test
         boolean checkFlag = properties != null && properties.getEnable();
         if (checkFlag) {
-            String propertiesClassName = properties.getClass().getName();
+            String propertiesClassName = properties.getClass().getSuperclass() == Object.class ? properties.getClass().getName() : properties.getClass().getSuperclass().getName();
             switch (propertiesClassName) {
                 case bootstrapPropertiesClassName: {
                     String namespace = properties.getNamespace();


### PR DESCRIPTION
Changes proposed in this pull request:
Fix the problem that the dynamicThreadPoolBeforeCheckBean method in the BeforeCheckConfiguration class cannot validate parameters effectively in the config mode.