### PR TITLE
修复：相同租户不同项目下，相同线程池id无法同时注册问题

### DIFF
--- a/threadpool/server/config/src/main/java/cn/hippo4j/config/service/biz/impl/ConfigServiceImpl.java
+++ b/threadpool/server/config/src/main/java/cn/hippo4j/config/service/biz/impl/ConfigServiceImpl.java
@@ -234,6 +234,8 @@ public class ConfigServiceImpl implements ConfigService {
             synchronized (ConfigService.class) {
                 ConfigAllInfo configAllInfo = configInfoMapper.selectOne(
                         Wrappers.lambdaQuery(ConfigAllInfo.class)
+                                .eq(ConfigAllInfo::getTenantId, config.getTenantId())
+                                .eq(ConfigAllInfo::getItemId, config.getItemId())
                                 .eq(ConfigAllInfo::getTpId, config.getTpId())
                                 .eq(ConfigAllInfo::getDelFlag, DelEnum.NORMAL.getIntCode()));
                 Assert.isNull(configAllInfo, "线程池配置已存在");


### PR DESCRIPTION
Fixes #1525 
现象：
<img width="703" alt="94bd73d724573ce808aab665add0515f" src="https://github.com/opengoofy/hippo4j/assets/54902951/705bb4c5-61b6-4455-aece-c30089680424">
server端控制台一直报错如下：
![image](https://github.com/opengoofy/hippo4j/assets/54902951/3c2b5423-bd2d-4a09-a25a-ed1bd06413b6)

前提：
数据库config表：只存在1条记录：租户:hudong、项目id：hd-feed-ext-service-test、线程池id：feed-rednum-push-bath
![image](https://github.com/opengoofy/hippo4j/assets/54902951/5442879e-4a0e-4d32-94b0-9415f1072b47)

步骤：
1. 启动第一个服务：租户:hudong、项目id：hd-feed-ext-service-test、线程池id：feed-rednum-push-bath，服务启动成功
2. 启动第一个服务：租户:hudong、项目id：hd-feed-ext-service-dev、线程池id：feed-rednum-push-bath，服务启动失败，如图：
 <img width="703" alt="94bd73d724573ce808aab665add0515f" src="https://github.com/opengoofy/hippo4j/assets/54902951/705bb4c5-61b6-4455-aece-c30089680424">


改动点：

1. 二次检查添加config表信息时，与首次检查查询维度相同:租户、项目id、线程池id