### PR TITLE
Remove the @NonNull annotation from final fields.

### DIFF
--- a/threadpool/core/src/main/java/cn/hippo4j/core/executor/plugin/impl/TaskRejectNotifyAlarmPlugin.java
+++ b/threadpool/core/src/main/java/cn/hippo4j/core/executor/plugin/impl/TaskRejectNotifyAlarmPlugin.java
@@ -21,7 +21,6 @@ import cn.hippo4j.core.config.ApplicationContextHolder;
 import cn.hippo4j.core.executor.ExtensibleThreadPoolExecutor;
 import cn.hippo4j.core.executor.plugin.RejectedAwarePlugin;
 import cn.hippo4j.threadpool.alarm.api.ThreadPoolCheckAlarm;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Optional;

--- a/threadpool/core/src/main/java/cn/hippo4j/core/executor/plugin/impl/TaskRejectNotifyAlarmPlugin.java
+++ b/threadpool/core/src/main/java/cn/hippo4j/core/executor/plugin/impl/TaskRejectNotifyAlarmPlugin.java
@@ -38,7 +38,6 @@ public class TaskRejectNotifyAlarmPlugin implements RejectedAwarePlugin {
     /**
      * Thread pool check alarm
      */
-    @NonNull
     private final ThreadPoolCheckAlarm threadPoolCheckAlarm;
 
     /**


### PR DESCRIPTION
Using the RequiredArgsConstructor annotation to add final has the same effect as using the @NonNull annotation, so the @NonNull annotation can be removed.
使用了 RequiredArgsConstructor 注解在加了 final 和使用 @NonNull 注解的效果是一样的，所以 @NonNull 注解可以删除

Changes proposed in this pull request:
- Remove extraneous comments to make the code more standardized.

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
