### PR TITLE
The generated code will use 'org.jetbrains.annotations.NotNull' instead of 'lombok.NonNull'.

### DIFF
--- a/threadpool/core/src/main/java/cn/hippo4j/core/executor/plugin/impl/TaskRejectNotifyAlarmPlugin.java
+++ b/threadpool/core/src/main/java/cn/hippo4j/core/executor/plugin/impl/TaskRejectNotifyAlarmPlugin.java
@@ -21,7 +21,6 @@ import cn.hippo4j.core.config.ApplicationContextHolder;
 import cn.hippo4j.core.executor.ExtensibleThreadPoolExecutor;
 import cn.hippo4j.core.executor.plugin.RejectedAwarePlugin;
 import cn.hippo4j.threadpool.alarm.api.ThreadPoolCheckAlarm;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Optional;

--- a/threadpool/core/src/main/java/cn/hippo4j/core/executor/plugin/impl/TaskRejectNotifyAlarmPlugin.java
+++ b/threadpool/core/src/main/java/cn/hippo4j/core/executor/plugin/impl/TaskRejectNotifyAlarmPlugin.java
@@ -38,7 +38,6 @@ public class TaskRejectNotifyAlarmPlugin implements RejectedAwarePlugin {
     /**
      * Thread pool check alarm
      */
-    @NonNull
     private final ThreadPoolCheckAlarm threadPoolCheckAlarm;
 
     /**


### PR DESCRIPTION
Fixes #ISSUSE_ID

Changes proposed in this pull request:
-  [Remove the @NonNull annotation from final fields.](https://github.com/opengoofy/hippo4j/pull/1564)

> Check mailbox configuration when submitting. [Contributor Guide](https://hippo4j.cn/community/contributor-guide)
